### PR TITLE
fix(frontend): use bolt icon instead of wand for magic link

### DIFF
--- a/frontend/app/components/magic-link-btn/template.hbs
+++ b/frontend/app/components/magic-link-btn/template.hbs
@@ -5,7 +5,7 @@
   class="btn btn-default"
   {{on "click" (toggle "isModalVisible" this)}}
 >
-  <FaIcon @icon="magic" @prefix="fas" /> 
+  <FaIcon @icon="bolt" @prefix="fas" /> 
 </button>
 
 {{#if this.isModalVisible}}


### PR DESCRIPTION
reference: #78