### PR TITLE
fix(backend): fix ProjectAssigneeInline has no attribute inlines error

### DIFF
--- a/backend/timed/projects/admin.py
+++ b/backend/timed/projects/admin.py
@@ -18,6 +18,7 @@ class CustomerAssigneeInline(admin.TabularInline):
 
 
 class ProjectAssigneeInline(admin.StackedInline):
+    inlines = ()
     autocomplete_fields = ("user",)
     model = models.ProjectAssignee
     extra = 0


### PR DESCRIPTION
this should make it so projects can be created via django admin again