### PR TITLE
fix(backend): only return employments and worktime-balances once

### DIFF
--- a/backend/timed/employment/views.py
+++ b/backend/timed/employment/views.py
@@ -219,7 +219,7 @@ class WorktimeBalanceViewSet(AggregateQuerysetMixin, ReadOnlyModelViewSet):
         if not user.is_superuser:
             queryset = queryset.filter(Q(id=user.id) | Q(supervisors=user))
 
-        return queryset
+        return queryset.distinct()
 
 
 class AbsenceBalanceViewSet(AggregateQuerysetMixin, ReadOnlyModelViewSet):
@@ -346,7 +346,7 @@ class EmploymentViewSet(ModelViewSet):
         if not user.is_superuser:
             queryset = queryset.filter(Q(user=user) | Q(user__supervisors=user))
 
-        return queryset
+        return queryset.distinct()
 
 
 class LocationViewSet(ReadOnlyModelViewSet):


### PR DESCRIPTION
before this employments and worktime-balances were returned an additional time for each supervisor.

very similar to #402 