### PR TITLE
magic link improvements

### DIFF
--- a/frontend/app/components/magic-link-modal/component.js
+++ b/frontend/app/components/magic-link-modal/component.js
@@ -4,6 +4,8 @@ import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 
 export default class MagicLinkModal extends Component {
+  @tracked customer;
+  @tracked project;
   @tracked task;
   @tracked duration;
   @tracked comment;
@@ -14,15 +16,12 @@ export default class MagicLinkModal extends Component {
 
   @service router;
 
-  @action
-  onSetTask(task) {
-    this.task = task;
-  }
-
   get magicLinkString() {
     const url = this.router.urlFor("index.reports", {
       queryParams: {
         task: this.task?.id,
+        project: this.task ? null : this.project?.id,
+        customer: this.task ? null : this.project ? null : this.customer?.id,
         comment: this.comment,
         duration: this.duration,
         review: this.review,

--- a/frontend/app/components/magic-link-modal/template.hbs
+++ b/frontend/app/components/magic-link-modal/template.hbs
@@ -17,7 +17,9 @@
         <TaskSelection
           @disabled={{false}}
           @task={{this.task}}
-          @on-set-task={{this.onSetTask}}
+          @on-set-customer={{fn (mut this.customer)}}
+          @on-set-project={{fn (mut this.project)}}
+          @on-set-task={{fn (mut this.task)}}
           as |t|
         >
           <div

--- a/frontend/app/components/report-row/component.js
+++ b/frontend/app/components/report-row/component.js
@@ -21,6 +21,10 @@ export default class ReportRowComponent extends Component {
         )} and therefore not editable anymore`;
   }
 
+  get initial() {
+    return this.args.report?.get("task.id") ? {} : this.args.initial;
+  }
+
   /**
    * Save the row
    *

--- a/frontend/app/components/report-row/template.hbs
+++ b/frontend/app/components/report-row/template.hbs
@@ -3,6 +3,7 @@
     <TaskSelection
       @disabled={{not this.editable}}
       @task={{cs.task}}
+      @initial={{this.initial}}
       @on-set-task={{fn this.updateTask cs}}
       as |t|
     >

--- a/frontend/app/index/reports/controller.js
+++ b/frontend/app/index/reports/controller.js
@@ -20,9 +20,20 @@ import { cached } from "tracked-toolbox";
  * @public
  */
 export default class IndexReportController extends Controller {
-  queryParams = ["task", "duration", "comment", "review", "notBillable"];
+  queryParams = [
+    "customer",
+    "project",
+    "task",
+    "duration",
+    "comment",
+    "review",
+    "notBillable",
+  ];
 
+  @tracked customer;
+  @tracked project;
   @tracked task;
+  @tracked initial;
   @tracked duration;
   @tracked comment;
   @tracked review = false;

--- a/frontend/app/index/reports/template.hbs
+++ b/frontend/app/index/reports/template.hbs
@@ -13,6 +13,7 @@
     {{#each this.reports as |report|}}
       <ReportRow
         @report={{report}}
+        @initial={{this.initial}}
         @onSave={{this.saveReport}}
         @onDelete={{this.deleteReport}}
         data-test-report-row-id={{report.id}}


### PR DESCRIPTION
Improve magic links by making it so just one of comment/duration/customer/project is enough to create a report

This is a draft for the following reasons:
- :spaghetti: code
- buggy (after saving a report created by a magic link that didn't have a task, it gets set to blank in the frontend)

