### PR TITLE
fix(backend): allow from_time and to_time to be the same

### DIFF
--- a/backend/timed/tracking/serializers.py
+++ b/backend/timed/tracking/serializers.py
@@ -109,11 +109,6 @@ class AttendanceSerializer(ModelSerializer):
         from_time = round_time(data.get("from_time", instance and instance.from_time))
         to_time = round_time(data.get("to_time", instance and instance.to_time))
 
-        if to_time == from_time:
-            raise ValidationError(
-                _("An attendance may not start and end at the same time.")
-            )
-
         # allow attendances to end at midnight (00:00)
         if to_time < from_time and to_time != time(0, 0):
             raise ValidationError(_("An attendance may not end before it starts."))

--- a/backend/timed/tracking/tests/test_attendance.py
+++ b/backend/timed/tracking/tests/test_attendance.py
@@ -122,13 +122,6 @@ def test_attendance_delete(internal_employee_client):
             "07:00",
             "An attendance may not end before it starts.",
         ),
-        (
-            time(7, 30),
-            time(8, 30),
-            "07:30",
-            "07:30",
-            "An attendance may not start and end at the same time.",
-        ),
     ],
 )
 def test_attendance_validation(


### PR DESCRIPTION
i noticed UX is worse when you can't have the same from and to time, also this would make it so 0:00 to 24:00 attendances aren't possible