### PR TITLE
chore(frontend): fix deprecations by using peekAll instead of fetchAll

### DIFF
--- a/frontend/app/analysis/index/controller.js
+++ b/frontend/app/analysis/index/controller.js
@@ -86,11 +86,11 @@ export default class AnalysisController extends QPController {
   @tracked comment;
 
   get billingTypes() {
-    return this.store.findAll("billing-type");
+    return this.store.peekAll("billing-type");
   }
 
   get costCenters() {
-    return this.store.findAll("cost-center");
+    return this.store.peekAll("cost-center");
   }
 
   get selectedCustomer() {

--- a/frontend/app/statistics/controller.js
+++ b/frontend/app/statistics/controller.js
@@ -73,11 +73,11 @@ export default class StatisticsController extends QPController {
   }
 
   get billingTypes() {
-    return this.store.findAll("billing-type");
+    return this.store.peekAll("billing-type");
   }
 
   get costCenters() {
-    return this.store.findAll("cost-center");
+    return this.store.peekAll("cost-center");
   }
 
   get selectedCustomer() {


### PR DESCRIPTION
this works because when prefetching data we already do a `findAll`