### PR TITLE
fix(frontend/dark): invert weekend/holiday and workday colours

### DIFF
--- a/frontend/app/styles/base.css
+++ b/frontend/app/styles/base.css
@@ -211,4 +211,7 @@
   --danger: color-mix(in srgb, rgb(var(--red)), rgb(var(--old-danger)));
 
   --clock: rgb(var(--foreground-muted));
+
+  --overview-workday: rgb(var(--old-weekend));
+  --overview-weekend: var(--secondary);
 }


### PR DESCRIPTION
is this really better?

now:
![image](https://github.com/user-attachments/assets/76ef6344-118e-4121-aedf-61d8b9905d29)

after:
![image](https://github.com/user-attachments/assets/a26b993b-f6b5-4b16-9755-7a48cd4a2040)
