### PR TITLE
fix(frontend/bulk-edit): unsaved changes warning for task when task not changed

### DIFF
--- a/frontend/app/analysis/edit/template.hbs
+++ b/frontend/app/analysis/edit/template.hbs
@@ -96,7 +96,7 @@
                         {{/unless}}
                         {{#if
                           (and
-                            f.model.change.task
+                            f.model.change.task.id
                             (not (eq f.model.change.task.id model.task.id))
                           )
                         }}


### PR DESCRIPTION
this was caused by

```hbs
{{#if
  (and
    f.model.change.task
    (not (eq f.model.change.task.id model.task.id))
  )
}}
  <ChangedWarning />
{{/if}}
```

when the changeset is modified `f.model.change.task` will be set to an empty object, this satisfies the first condition as objects are always truthy:

```hbs
{{#if
  (and
    {}
    (not (eq f.model.change.task.id model.task.id))
  )
}}
  <ChangedWarning />
{{/if}}
```

when we now look at the values of `f.model.change.task.id` and `model.task.id`, we can see that: `f.model.change.task.id` -> `undefined`
`model.task.id` -> `null`

`null` and `undefined` aren't the same, therefore: `(not (eq f.model.change.task.id model.task.id))` -> `(not (eq undefined null))` -> `(not (false))` -> `true`

because of that, modifying another value of the changeset resulted in:

```hbs
{{#if
  (and
    {}
    true
  )
}}
  <ChangedWarning />
{{/if}}
```