### PR TITLE
fix(frontend/statistics): show budget line when over budget

### DIFF
--- a/frontend/app/components/statistic-list/bar.hbs
+++ b/frontend/app/components/statistic-list/bar.hbs
@@ -19,7 +19,12 @@
   {{#if @goal}}
     <div
       ...attributes
-      class="statistic-list-bar-goal before:border-danger before:border-r-2 before:border-dotted"
+      class="statistic-list-bar-goal z-20 before:border-r-2 before:border-dotted
+        {{if
+          (gt @value @goal)
+          'before:border-foreground-primary'
+          'before:border-danger'
+        }}"
       {{style --value=(concat (min "0.99" @goal))}}
     ></div>
   {{/if}}


### PR DESCRIPTION
line is now visible, and white when over budget, fixes #582
![image](https://github.com/user-attachments/assets/a6cc6eb9-5eae-46cb-af40-9def7c30cfd2)
