### PR TITLE
feat(redmine): Display billable hours

### DIFF
--- a/backend/timed/redmine/templates/redmine/weekly_report.txt
+++ b/backend/timed/redmine/templates/redmine/weekly_report.txt
@@ -4,6 +4,7 @@ Customer: {{project.customer.name}}
 Project: {{project.name}}
 Hours in last {{last_days}} days: {{hours}}
 Total hours: {{total_hours}}
+Billable hours: {{billable_hours}}
 Estimated hours: {{estimated_hours}}
 
 


### PR DESCRIPTION
As we often have to subtract the non-billable hours from project estimation calculations & customer communication, it would be super neat to see the current *billable* hours in the redmine report.

I wondered if it's hard to implement and it looks rather trivial. Though I'm a bit overwhelmed with the testing and would be glad to have some pointers.