### PR TITLE
chore(frontend): make eslint config stricter

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -4,8 +4,6 @@ module.exports = {
   extends: ["@adfinis/eslint-config/ember-app"],
   rules: {
     "ember/no-component-lifecycle-hooks": "warn",
-    "ember/no-mixins": "warn",
-    "ember/no-new-mixins": "warn",
     "ember/no-classic-classes": "warn",
     "ember/no-classic-components": "warn",
     "ember/no-get": "warn",

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -3,7 +3,6 @@
 module.exports = {
   extends: ["@adfinis/eslint-config/ember-app"],
   rules: {
-    "ember/no-actions-hash": "warn",
     "ember/no-component-lifecycle-hooks": "warn",
     "ember/no-mixins": "warn",
     "ember/no-new-mixins": "warn",

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -4,8 +4,6 @@ module.exports = {
   extends: ["@adfinis/eslint-config/ember-app"],
   rules: {
     "ember/no-component-lifecycle-hooks": "warn",
-    "ember/no-classic-classes": "warn",
-    "ember/no-classic-components": "warn",
     "ember/no-get": "warn",
     "ember/no-observers": "warn",
     "qunit/no-assert-equal": "warn",

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -5,6 +5,5 @@ module.exports = {
   rules: {
     "ember/no-observers": "warn",
     "qunit/no-assert-equal": "warn",
-    "ember/require-tagless-components": "warn",
   },
 };

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -3,7 +3,6 @@
 module.exports = {
   extends: ["@adfinis/eslint-config/ember-app"],
   rules: {
-    "ember/no-component-lifecycle-hooks": "warn",
     "ember/no-get": "warn",
     "ember/no-observers": "warn",
     "qunit/no-assert-equal": "warn",

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -3,7 +3,6 @@
 module.exports = {
   extends: ["@adfinis/eslint-config/ember-app"],
   rules: {
-    "ember/no-get": "warn",
     "ember/no-observers": "warn",
     "qunit/no-assert-equal": "warn",
     "ember/require-tagless-components": "warn",

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -4,6 +4,5 @@ module.exports = {
   extends: ["@adfinis/eslint-config/ember-app"],
   rules: {
     "ember/no-observers": "warn",
-    "qunit/no-assert-equal": "warn",
   },
 };


### PR DESCRIPTION
we can make these error instead of warn as they're no longer used anywhere