### PR TITLE
feat: allow bulk edit of verify and review

### DIFF
--- a/backend/timed/tracking/views.py
+++ b/backend/timed/tracking/views.py
@@ -251,10 +251,23 @@ class ReportViewSet(ModelViewSet):
 
             fields["verified_by"] = (verified and user) or None
 
-            if fields.get("review") or any(queryset.values_list("review", flat=True)):
+            if (
+                any(queryset.values_list("review", flat=True))
+                and verified
+                and fields.get("review")
+            ) or (verified and fields.get("review")):
                 raise exceptions.ParseError(
                     _("Reports can't both be set as `review` and `verified`.")
                 )
+
+        if (
+            verified is None
+            and fields.get("review")
+            and any(queryset.values_list("verified_by", flat=True))
+        ):
+            raise exceptions.ParseError(
+                _("Reports can't both be set as `review` and `verified`.")
+            )
 
         if serializer.validated_data.get("billed", None) is not None and not (
             user.is_superuser or user.is_accountant

--- a/frontend/app/analysis/edit/controller.js
+++ b/frontend/app/analysis/edit/controller.js
@@ -158,11 +158,27 @@ export default class AnalysisEditController extends Controller {
     return this.isAccountant || this.isSuperuser;
   }
 
-  get needsReview() {
+  @action
+  needsReview(form) {
     return (
-      this.intersectionModel?.review === null ||
-      this.intersectionModel?.review === true
+      (this.intersectionModel?.review === null ||
+        this.intersectionModel?.review === true) &&
+      form.model.change?.review !== false
     );
+  }
+
+  @action
+  showVerifiedWarning(form) {
+    const review =
+      form.model.change?.review !== undefined
+        ? form.model.change?.review
+        : form.model.data.review;
+    const verified =
+      form.model.change?.verified !== undefined
+        ? form.model.change?.verified
+        : form.model.data.verified;
+
+    return verified && review;
   }
 
   get toolTipText() {

--- a/frontend/app/analysis/edit/template.hbs
+++ b/frontend/app/analysis/edit/template.hbs
@@ -215,7 +215,10 @@
                         @checked={{fi.value}}
                         @onChange={{fi.update}}
                         @title={{this.toolTipText}}
-                        @disabled={{or (not this.canVerify) this.needsReview}}
+                        @disabled={{or
+                          (not this.canVerify)
+                          (this.needsReview f)
+                        }}
                       >
                         Verified
                         {{#if (eq model.verified null)}}
@@ -223,6 +226,16 @@
                         {{/if}}
                         {{#if (not-eq f.model.verified model.verified)}}
                           <ChangedWarning />
+                        {{/if}}
+                        {{#if (this.showVerifiedWarning f)}}
+                          <span class="text-warning ml-2">
+                            <FaIcon
+                              @icon="exclamation-triangle"
+                              @prefix="fas"
+                            />
+                            Reports can't be "needs review" and "verified" at
+                            the same time.
+                          </span>
                         {{/if}}
                       </Checkbox>
                     </f.input>


### PR DESCRIPTION
Currently it's not possible to bulk edit any reports that have the "needs review" flag set. This MR addresses this and shows you a warning (and then the backend throws an error) if you try to save an invalid combination of verify and review.

![image](https://github.com/user-attachments/assets/fbed7041-2a05-4ec4-92e7-daefcda6cabb)

![image](https://github.com/user-attachments/assets/278e0d2a-d636-4bb8-b80d-a0f90b719cbf)
