### PR TITLE
chore: fix .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,2 @@
-dc23e79e68e4e2bfda79be52e342ea7b322d1150 # copied over customer center
-0d3f7397a97111a82e0ecbf65e88b31ef9547ee0 # copied over customer center chart
+d1cf518b46cf33d8c0515676e4ba3264247b34d4 # copied over customer-center
+52dd58eda79155cde627ab3d76e939f467d6c3e2 # copied over customer-center chart


### PR DESCRIPTION
when merging the digests of the commits changed (which makes sense) this commit updates it to use the correct (post merge) digests so it actually works