### PR TITLE
fix(chart): restart deployment on configmap change

### DIFF
--- a/charts/customer-center/templates/deployment.yaml
+++ b/charts/customer-center/templates/deployment.yaml
@@ -15,6 +15,8 @@ spec:
       labels:
         {{- include "customerCenter.labels" . | nindent 8 }}
         app.kubernetes.io/component: frontend
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     spec:
       containers:
         - name: {{ .Chart.Name }}

--- a/charts/timed/templates/deployment-backend.yaml
+++ b/charts/timed/templates/deployment-backend.yaml
@@ -17,6 +17,9 @@ spec:
       labels:
         {{- include "timed.labels" . | nindent 8 }}
         app.kubernetes.io/component: backend
+      annotations:
+        checksum/config-backend: {{ include (print $.Template.BasePath "/configmap-backend.yaml") . | sha256sum }}
+        checksum/config-workreport: {{ include (print $.Template.BasePath "/configmap-workreport.yaml") . | sha256sum }}
     spec:
       containers:
         - name: {{ .Chart.Name }}-backend

--- a/charts/timed/templates/deployment-frontend.yaml
+++ b/charts/timed/templates/deployment-frontend.yaml
@@ -17,6 +17,8 @@ spec:
       labels:
         {{- include "timed.labels" . | nindent 8 }}
         app.kubernetes.io/component: frontend
+      annotations:
+        checksum/config-frontend: {{ include (print $.Template.BasePath "/configmap-frontend.yaml") . | sha256sum }}
     spec:
       containers:
         - name: {{ .Chart.Name }}-frontend


### PR DESCRIPTION
Currently, one has to manually restart a deployment after editing the corresponding `ConfigMap`. This can lead to unintended side effects as ArgoCD reports the status as `Synced` while e.g. the frontend is still running with old an config.

This PR adds a `checksum/config[-.*]` annotation to Deployments, which contains the sha256 sum of the respective ConfigMap.

This means, when the ConfigMap is changed in the future, Helm will detect a difference and the deployment will automatically restart.