### PR TITLE
chore(ci): dependabot cooldown for all ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       interval: daily
       time: "12:00"
       timezone: "Europe/Zurich"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: pip
     directory: "/backend"
@@ -18,6 +20,8 @@ updates:
       prefix: chore
       include: scope
     open-pull-requests-limit: 15
+    cooldown:
+      default-days: 7
 
     groups:
       pytest:
@@ -34,6 +38,8 @@ updates:
     commit-message:
       prefix: chore
       include: scope
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: docker
     directory: "/frontend"
@@ -44,6 +50,8 @@ updates:
     commit-message:
       prefix: chore
       include: scope
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: npm
     directory: "/frontend"
@@ -55,6 +63,8 @@ updates:
     commit-message:
       prefix: chore
       include: scope
+    cooldown:
+      default-days: 7
 
     groups:
       lint:


### PR DESCRIPTION
Activate a default cooldown of 7 days for all ecosystems.

* fixes #1145