### PR TITLE
feat: change needs_review and verified in one save

### DIFF
--- a/backend/timed/tracking/tests/test_report.py
+++ b/backend/timed/tracking/tests/test_report.py
@@ -807,18 +807,35 @@ def test_report_update_by_user(
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
+@pytest.mark.parametrize(
+    ("needs_review", "needs_review_flag", "expected_status"),
+    [
+        (True, False, status.HTTP_200_OK),
+        (False, True, status.HTTP_400_BAD_REQUEST),
+    ],
+)
 def test_report_update_verified_and_review_reviewer(
-    internal_employee_client, report_factory, project_assignee_factory
+    internal_employee_client,
+    report_factory,
+    project_assignee_factory,
+    needs_review,
+    expected_status,
+    needs_review_flag,
 ):
     user = internal_employee_client.user
     report = report_factory(duration=timedelta(hours=2))
     project_assignee_factory(user=user, project=report.task.project, is_reviewer=True)
+    user = internal_employee_client.user
+    report = report_factory.create(duration=timedelta(hours=2), review=needs_review)
+    project_assignee_factory.create(
+        user=user, project=report.task.project, is_reviewer=True
+    )
 
     data = {
         "data": {
             "type": "reports",
             "id": report.id,
-            "attributes": {"review": True},
+            "attributes": {"review": needs_review_flag},
             "relationships": {
                 "verified-by": {"data": {"id": user.pk, "type": "users"}}
             },
@@ -828,7 +845,7 @@ def test_report_update_verified_and_review_reviewer(
     url = reverse("report-detail", args=[report.id])
 
     res = internal_employee_client.patch(url, data)
-    assert res.status_code == status.HTTP_400_BAD_REQUEST
+    assert res.status_code == expected_status
 
 
 def test_report_set_verified_by_user(

--- a/backend/timed/tracking/views.py
+++ b/backend/timed/tracking/views.py
@@ -213,17 +213,12 @@ class ReportViewSet(ModelViewSet):
         serializer = self.get_serializer(data)
         return Response(data=serializer.data)
 
-    def _validate_verified(self, queryset, fields, user, qp):
+    def _validate_verified(self, fields, user, qp):
         # only reviewer or superuser may verify reports
         # this is enforced when reviewer filter is set to current user
         if not user.is_superuser and str(qp.get("reviewer")) != str(user.id):
             raise exceptions.ValidationError(
                 _("Reviewer filter needs to be set to verifying user")
-            )
-
-        if fields.get("review") or any(queryset.values_list("review", flat=True)):
-            raise exceptions.ValidationError(
-                _("Reports can't both be set as `review` and `verified`.")
             )
 
         if fields.get("task"):
@@ -262,6 +257,7 @@ class ReportViewSet(ModelViewSet):
         serializer.is_valid(raise_exception=True)
 
         verified = serializer.validated_data.pop("verified", None)
+        review = serializer.validated_data.get("review")
         fields = {
             key: value
             for key, value in serializer.validated_data.items()
@@ -283,9 +279,22 @@ class ReportViewSet(ModelViewSet):
                 _("Only superuser and accountants may bill reports")
             )
 
+        effective_verified = any(queryset.values_list("verified_by_id", flat=True))
+
         if verified is not None:
-            self._validate_verified(queryset, fields, user, qp)
+            self._validate_verified(fields, user, qp)
             fields["verified_by"] = (verified and user) or None
+
+            effective_verified = verified
+
+        effective_review = (
+            review if review is not None else queryset.filter(review=True).exists()
+        )
+
+        if effective_review and effective_verified:
+            raise exceptions.ValidationError(
+                _("Reports can't both be set as `review` and `verified`.")
+            )
 
         review_comment = fields.pop("review_comment", "")
 

--- a/ember/frontend/app/analysis/edit/template.gjs
+++ b/ember/frontend/app/analysis/edit/template.gjs
@@ -192,6 +192,11 @@ import Void from "timed/components/void";
                             data-test-review
                             @checked={{fi.value}}
                             @onChange={{fi.update}}
+                            @disabled={{and
+                              f.model.verified
+                              (notEq f.model.review null)
+                              (not f.model.review)
+                            }}
                           >
                             Needs Review
                             {{#if (eq model.review null)}}
@@ -268,7 +273,11 @@ import Void from "timed/components/void";
                             @title={{@controller.toolTipText}}
                             @disabled={{or
                               (not @controller.canVerify)
-                              @controller.needsReview
+                              (and
+                                f.model.review
+                                (notEq f.model.verified null)
+                                (not f.model.verified)
+                              )
                             }}
                           >
                             Verified


### PR DESCRIPTION
Previously you had to first uncheck the needs_review flag, save, check verified and save again to change a report from review to verified. With this change you can do that in one go.

Ref: #60 