### PR TITLE
Split report by reviewer via modal ( Frontend Side Only )

### DIFF
--- a/ember/frontend/app/analysis/edit/controller.js
+++ b/ember/frontend/app/analysis/edit/controller.js
@@ -59,6 +59,7 @@ export default class AnalysisEditController extends Controller {
   @service currentUser;
   @service store;
   @service unverifiedReports;
+  @service abilities;
 
   @tracked id;
   @tracked user;
@@ -152,6 +153,10 @@ export default class AnalysisEditController extends Controller {
       return false;
     }
     return this.isReviewer || this.isSuperuser;
+  }
+
+  get canSplitReport() {
+    return this.id?.length === 1;
   }
 
   get canBill() {

--- a/ember/frontend/app/analysis/edit/template.gjs
+++ b/ember/frontend/app/analysis/edit/template.gjs
@@ -15,6 +15,7 @@ import Empty from "timed/components/empty";
 import NotIdenticalWarning from "timed/components/not-identical-warning";
 import PagePermission from "timed/components/page-permission";
 import ReportComment from "timed/components/report-comment";
+import SplitReportModal from "timed/components/split-report-modal";
 import TaskSelection from "timed/components/task-selection";
 import Void from "timed/components/void";
 
@@ -320,6 +321,11 @@ import Void from "timed/components/void";
                             )
                           }}
                         >Reset</button>
+                        <SplitReportModal
+                          @afterSave={{@controller.cancel}}
+                          @disabled={{not @controller.canSplitReport}}
+                          @report-id={{@controller.id}}
+                        />
                       </div>
                       <f.submit />
                     </c.footer>

--- a/ember/frontend/app/components/split-report-modal.gjs
+++ b/ember/frontend/app/components/split-report-modal.gjs
@@ -49,16 +49,6 @@ export default class SplitReportModal extends Component {
     this.isModalVisible = true;
   }
 
-  @action
-  onSetOldTask(task) {
-    this.oldTask = task;
-  }
-
-  @action
-  onSetNewTask(task) {
-    this.newTask = task;
-  }
-
   get remainingOldDuration() {
     const remaining = this.oldDuration.minus(this.newDuration);
     return remaining.as("milliseconds") > 0
@@ -108,17 +98,26 @@ export default class SplitReportModal extends Component {
 
       await this.fetch.fetch(`/api/v1/reports/${reportId}/split`, {
         method: "POST",
-        body: {
-          old_report: {
-            task: this.oldTask.id,
-            comment: this.oldComment,
-            duration: durationTransform.serialize(this.remainingOldDuration),
+        data: {
+          attributes: {
+            updated_original_report: {
+              task: {
+                type: "tasks",
+                id: this.oldTask.id,
+              },
+              comment: this.oldComment,
+              duration: durationTransform.serialize(this.remainingOldDuration),
+            },
+            second_report: {
+              task: {
+                type: "tasks",
+                id: this.newTask.id,
+              },
+              comment: this.newComment,
+              duration: durationTransform.serialize(this.newDuration),
+            },
           },
-          new_report: {
-            task: this.newTask.id,
-            comment: this.newComment,
-            duration: durationTransform.serialize(this.newDuration),
-          },
+          type: "split-reports",
         },
       });
 
@@ -173,7 +172,7 @@ export default class SplitReportModal extends Component {
                 <p class="text-muted-foreground text-sm font-semibold">Original
                   report</p>
                 <TaskSelection
-                  @on-set-task={{this.onSetOldTask}}
+                  @on-set-task={{fn (mut this.oldTask)}}
                   @task={{this.oldTask}}
                   as |t|
                 >
@@ -204,7 +203,7 @@ export default class SplitReportModal extends Component {
               <div class="flex flex-col gap-2">
                 <p class="text-muted-foreground text-sm font-semibold">Second
                   Report</p>
-                <TaskSelection @on-set-task={{this.onSetNewTask}} as |t|>
+                <TaskSelection @on-set-task={{fn (mut this.newTask)}} as |t|>
                   <t.customer @dropdownClass="z-[60]" />
                   <t.project @dropdownClass="z-[60]" />
                   <t.task @dropdownClass="z-[60]" />
@@ -235,6 +234,7 @@ export default class SplitReportModal extends Component {
             <button
               class="btn btn-default"
               type="button"
+              data-test-split-report-cancel
               {{on "click" this.closeModal}}
             >
               Cancel
@@ -242,6 +242,7 @@ export default class SplitReportModal extends Component {
             <button
               class="btn btn-primary ms-auto"
               type="button"
+              data-test-split-report-confirm
               {{on "click" (perform this.splitReport)}}
               disabled={{or (not this.isValidSplit) this.splitReport.isRunning}}
             >

--- a/ember/frontend/app/components/split-report-modal.gjs
+++ b/ember/frontend/app/components/split-report-modal.gjs
@@ -10,7 +10,7 @@ import perform from "ember-concurrency/helpers/perform";
 import { not, or } from "ember-truth-helpers";
 import { Duration } from "luxon";
 
-import DurationpickerDay from "timed/components/durationpicker-day";
+import Durationpicker from "timed/components/durationpicker";
 import Modal from "timed/components/modal";
 import TaskSelection from "timed/components/task-selection";
 import DjangoDurationTransform from "timed/transforms/django-duration";
@@ -194,7 +194,7 @@ export default class SplitReportModal extends Component {
                     aria-label="Comment for original report"
                   />
                 </div>
-                <DurationpickerDay
+                <Durationpicker
                   @value={{this.remainingOldDuration}}
                   @onChange={{this.onRemainingDurationChange}}
                   @title="Remaining duration"
@@ -222,7 +222,7 @@ export default class SplitReportModal extends Component {
                     aria-label="Comment for new report"
                   />
                 </div>
-                <DurationpickerDay
+                <Durationpicker
                   @value={{this.newDuration}}
                   @onChange={{this.onNewDurationChange}}
                   @title="Duration for new report"

--- a/ember/frontend/app/components/split-report-modal.gjs
+++ b/ember/frontend/app/components/split-report-modal.gjs
@@ -1,0 +1,255 @@
+import { fn } from "@ember/helper";
+import { on } from "@ember/modifier";
+import { action } from "@ember/object";
+import { service } from "@ember/service";
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import pick from "@nullvoxpopuli/ember-composable-helpers/helpers/pick";
+import { task } from "ember-concurrency";
+import perform from "ember-concurrency/helpers/perform";
+import { not, or } from "ember-truth-helpers";
+import { Duration } from "luxon";
+
+import DurationpickerDay from "timed/components/durationpicker-day";
+import Modal from "timed/components/modal";
+import TaskSelection from "timed/components/task-selection";
+import DjangoDurationTransform from "timed/transforms/django-duration";
+
+export default class SplitReportModal extends Component {
+  @tracked isModalVisible = false;
+  @service fetch;
+  @service notify;
+  @service store;
+
+  @tracked newTask = null;
+  @tracked newComment = "";
+  @tracked newDuration = Duration.fromMillis(0);
+
+  @tracked oldTask = null;
+  @tracked oldComment = "";
+  @tracked oldDuration = Duration.fromMillis(0);
+
+  get report() {
+    return this.fetchReport.lastSuccessful?.value;
+  }
+
+  fetchReport = task(async () => {
+    return await this.store.findRecord("report", this.args["report-id"][0]);
+  });
+
+  @action
+  async showModal() {
+    const report = await this.fetchReport.perform();
+    this.oldTask = report.task ?? null;
+    this.oldComment = report.comment ?? "";
+    this.oldDuration = report.duration ?? Duration.fromMillis(0);
+    this.newDuration = Duration.fromMillis(0);
+    this.newComment = "";
+    this.newTask = null;
+    this.isModalVisible = true;
+  }
+
+  @action
+  onSetOldTask(task) {
+    this.oldTask = task;
+  }
+
+  @action
+  onSetNewTask(task) {
+    this.newTask = task;
+  }
+
+  get remainingOldDuration() {
+    const remaining = this.oldDuration.minus(this.newDuration);
+    return remaining.as("milliseconds") > 0
+      ? remaining
+      : Duration.fromMillis(0);
+  }
+
+  @action
+  onNewDurationChange(value) {
+    const totalMs = this.oldDuration.as("milliseconds");
+    const ms = Math.min(value?.as("milliseconds") ?? 0, totalMs);
+    this.newDuration = Duration.fromMillis(Math.max(ms, 0));
+  }
+
+  @action
+  onRemainingDurationChange(value) {
+    const totalMs = this.oldDuration.as("milliseconds");
+    const remainingMs = Math.min(value?.as("milliseconds") ?? 0, totalMs);
+    this.newDuration = Duration.fromMillis(Math.max(totalMs - remainingMs, 0));
+  }
+
+  get isValidSplit() {
+    if (!this.newTask) return false;
+    if (!this.newDuration || this.newDuration.as("milliseconds") <= 0) {
+      return false;
+    }
+    if (
+      !this.oldDuration ||
+      this.newDuration.as("milliseconds") >= this.oldDuration.as("milliseconds")
+    ) {
+      return false;
+    }
+    return true;
+  }
+
+  splitReport = task(async () => {
+    if (!this.isValidSplit) {
+      this.notify.error(
+        "Please select a task and enter a valid duration for the new report.",
+      );
+      return;
+    }
+
+    try {
+      const reportId = this.args["report-id"][0];
+      const durationTransform = DjangoDurationTransform.create();
+
+      await this.fetch.fetch(`/api/v1/reports/${reportId}/split`, {
+        method: "POST",
+        body: {
+          old_report: {
+            task: this.oldTask.id,
+            comment: this.oldComment,
+            duration: durationTransform.serialize(this.remainingOldDuration),
+          },
+          new_report: {
+            task: this.newTask.id,
+            comment: this.newComment,
+            duration: durationTransform.serialize(this.newDuration),
+          },
+        },
+      });
+
+      this.store.unloadRecord(this.report);
+
+      this.notify.success("Report split successfully.");
+      this.isModalVisible = false;
+      if (this.args.afterSave && typeof this.args.afterSave === "function") {
+        this.args.afterSave();
+      }
+    } catch {
+      this.notify.error("Could not split the report.");
+    }
+  });
+
+  @action
+  closeModal() {
+    this.isModalVisible = false;
+  }
+
+  <template>
+    <button
+      data-test-split-report
+      type="button"
+      class="btn btn-success"
+      {{on "click" this.showModal}}
+      disabled={{@disabled}}
+      title={{if
+        @disabled
+        "Only if there is one report selected, and the report is not verified"
+      }}
+      ...attributes
+    >
+      Split Report
+    </button>
+    {{#if this.isModalVisible}}
+      <Modal
+        @visible={{this.isModalVisible}}
+        @onClose={{this.closeModal}}
+        @closeOnBackdropClick={{false}}
+        class="md:w-auto"
+        as |modal|
+      >
+        <div class="sm:min-w-[64rem]">
+          <modal.header>
+            <h3>Split Report</h3>
+          </modal.header>
+          <modal.body>
+            <div class="grid grid-cols-2 gap-6">
+
+              <div class="flex flex-col gap-2">
+                <p class="text-muted-foreground text-sm font-semibold">Original
+                  report</p>
+                <TaskSelection
+                  @on-set-task={{this.onSetOldTask}}
+                  @task={{this.oldTask}}
+                  as |t|
+                >
+                  <t.customer @dropdownClass="z-[60]" />
+                  <t.project @dropdownClass="z-[60]" />
+                  <t.task @dropdownClass="z-[60]" />
+                </TaskSelection>
+                <div class="flex flex-col gap-1">
+                  <label class="text-sm font-medium">Comment</label>
+                  <input
+                    value={{this.oldComment}}
+                    type="text"
+                    {{on
+                      "change"
+                      (pick "target.value" (fn (mut this.oldComment)))
+                    }}
+                    class="ember-text-field form-control rounded"
+                    aria-label="Comment for original report"
+                  />
+                </div>
+                <DurationpickerDay
+                  @value={{this.remainingOldDuration}}
+                  @onChange={{this.onRemainingDurationChange}}
+                  @title="Remaining duration"
+                />
+              </div>
+
+              <div class="flex flex-col gap-2">
+                <p class="text-muted-foreground text-sm font-semibold">Second
+                  Report</p>
+                <TaskSelection @on-set-task={{this.onSetNewTask}} as |t|>
+                  <t.customer @dropdownClass="z-[60]" />
+                  <t.project @dropdownClass="z-[60]" />
+                  <t.task @dropdownClass="z-[60]" />
+                </TaskSelection>
+                <div class="flex flex-col gap-1">
+                  <label class="text-sm font-medium">Comment</label>
+                  <input
+                    value={{this.newComment}}
+                    type="text"
+                    {{on
+                      "change"
+                      (pick "target.value" (fn (mut this.newComment)))
+                    }}
+                    class="ember-text-field form-control rounded"
+                    aria-label="Comment for new report"
+                  />
+                </div>
+                <DurationpickerDay
+                  @value={{this.newDuration}}
+                  @onChange={{this.onNewDurationChange}}
+                  @title="Duration for new report"
+                />
+              </div>
+
+            </div>
+          </modal.body>
+          <modal.footer class="flex gap-2">
+            <button
+              class="btn btn-default"
+              type="button"
+              {{on "click" this.closeModal}}
+            >
+              Cancel
+            </button>
+            <button
+              class="btn btn-primary ms-auto"
+              type="button"
+              {{on "click" (perform this.splitReport)}}
+              disabled={{or (not this.isValidSplit) this.splitReport.isRunning}}
+            >
+              Split
+            </button>
+          </modal.footer>
+        </div>
+      </Modal>
+    {{/if}}
+  </template>
+}

--- a/ember/frontend/tests/integration/components/split-report-modal/component-test.gjs
+++ b/ember/frontend/tests/integration/components/split-report-modal/component-test.gjs
@@ -197,7 +197,7 @@ module("Integration | Component | split report modal", function (hooks) {
 
     await openModal();
 
-    assert.dom(".modal-footer .btn-primary").isDisabled();
+    assert.dom("[data-test-split-report-confirm]").isDisabled();
   });
 
   test("cancel button closes the modal", async function (assert) {
@@ -211,7 +211,7 @@ module("Integration | Component | split report modal", function (hooks) {
     await openModal();
     assert.dom(".modal-header").exists();
 
-    await click(".modal-footer .btn-default");
+    await click("[data-test-split-report-cancel]");
 
     assert.dom(".modal-header").doesNotExist();
   });
@@ -275,7 +275,7 @@ module("Integration | Component | split report modal", function (hooks) {
 
     await openModal();
     await fillIn("[aria-label='Comment for new report']", "temp comment");
-    await click(".modal-footer .btn-default");
+    await click("[data-test-split-report-cancel]");
 
     await openModal();
 
@@ -302,10 +302,16 @@ module("Integration | Component | split report modal", function (hooks) {
     await openModal();
     await selectNewTask();
     await setNewDuration("0:30");
-    await click(".modal-footer .btn-primary");
+    await click("[data-test-split-report-confirm]");
 
-    assert.ok(capturedBody.old_report, "old_report is present in payload");
-    assert.ok(capturedBody.new_report, "new_report is present in payload");
+    assert.ok(
+      capturedBody.data.attributes.updated_original_report,
+      "updated_original_report is present in payload",
+    );
+    assert.ok(
+      capturedBody.data.attributes.second_report,
+      "second_report is present in payload",
+    );
   });
 
   test("sends modified old report data to the split endpoint", async function (assert) {
@@ -331,15 +337,15 @@ module("Integration | Component | split report modal", function (hooks) {
     );
     await selectNewTask();
     await setNewDuration("0:30");
-    await click(".modal-footer .btn-primary");
+    await click("[data-test-split-report-confirm]");
 
     assert.strictEqual(
-      capturedBody.old_report.comment,
+      capturedBody.data.attributes.updated_original_report.comment,
       "Updated old comment",
       "sends updated old comment",
     );
     assert.strictEqual(
-      capturedBody.old_report.duration,
+      capturedBody.data.attributes.updated_original_report.duration,
       "00:30:00",
       "old report duration is the remaining time after split",
     );
@@ -365,15 +371,15 @@ module("Integration | Component | split report modal", function (hooks) {
     await selectNewTask();
     await fillIn("[aria-label='Comment for new report']", "New report comment");
     await setNewDuration("0:30");
-    await click(".modal-footer .btn-primary");
+    await click("[data-test-split-report-confirm]");
 
     assert.strictEqual(
-      capturedBody.new_report.comment,
+      capturedBody.data.attributes.second_report.comment,
       "New report comment",
       "sends new report comment",
     );
     assert.strictEqual(
-      capturedBody.new_report.duration,
+      capturedBody.data.attributes.second_report.duration,
       "00:30:00",
       "sends new report duration",
     );
@@ -400,7 +406,7 @@ module("Integration | Component | split report modal", function (hooks) {
     await openModal();
     await selectNewTask();
     await setNewDuration("0:30");
-    await click(".modal-footer .btn-primary");
+    await click("[data-test-split-report-confirm]");
 
     assert.dom(".modal-header").doesNotExist("modal is closed after split");
     assert.true(afterSaveCalled, "afterSave is called after successful split");
@@ -426,7 +432,7 @@ module("Integration | Component | split report modal", function (hooks) {
     await openModal();
     await selectNewTask();
     await setNewDuration("0:30");
-    await click(".modal-footer .btn-primary");
+    await click("[data-test-split-report-confirm]");
 
     assert.dom(".modal-header").exists("modal stays open on error");
   });
@@ -459,7 +465,7 @@ module("Integration | Component | split report modal", function (hooks) {
     await openModal();
     await selectNewTask();
     await setNewDuration("0:30");
-    await click(".modal-footer .btn-primary");
+    await click("[data-test-split-report-confirm]");
 
     assert.false(afterSaveCalled, "afterSave is not called on error");
   });
@@ -484,7 +490,7 @@ module("Integration | Component | split report modal", function (hooks) {
 
     await openModal();
 
-    assert.dom(".modal-footer .btn-primary").isDisabled();
+    assert.dom("[data-test-split-report-confirm]").isDisabled();
     assert.false(afterSaveCalled, "afterSave was not called for invalid split");
   });
 });

--- a/ember/frontend/tests/integration/components/split-report-modal/component-test.gjs
+++ b/ember/frontend/tests/integration/components/split-report-modal/component-test.gjs
@@ -1,0 +1,490 @@
+import Service from "@ember/service";
+import { click, fillIn, render, triggerEvent } from "@ember/test-helpers";
+import { selectChoose } from "ember-power-select/test-support";
+import { setupRenderingTest } from "ember-qunit";
+import { module, test } from "qunit";
+
+import ModalTarget from "timed/components/modal-target";
+import SplitReportModal from "timed/components/split-report-modal";
+import { setupMirage } from "timed/tests/helpers/mirage";
+
+const NEW_REPORT_COL = ".modal-body .grid > div:last-child";
+
+module("Integration | Component | split report modal", function (hooks) {
+  setupRenderingTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function () {
+    this.report = this.server.create("report", {
+      comment: "Original comment",
+      duration: "01:00:00",
+    });
+    this.reportId = [String(this.report.id)];
+
+    this.server.get("/reports/:id", function (schema, request) {
+      const report = schema.reports.find(request.params.id);
+      const serialized = this.serialize(report);
+      const task = schema.tasks.find(report.taskId);
+      if (task) {
+        serialized.included = [this.serialize(task).data];
+      }
+      return serialized;
+    });
+
+    this.server.post("/reports/:id/split", () => ({ data: {} }));
+  });
+
+  async function openModal() {
+    await click("[data-test-split-report]");
+  }
+
+  async function selectNewTask() {
+    await selectChoose(
+      `${NEW_REPORT_COL} .customer-select`,
+      ".ember-power-select-option",
+      1,
+    );
+    await selectChoose(
+      `${NEW_REPORT_COL} .project-select`,
+      ".ember-power-select-option",
+      0,
+    );
+    await selectChoose(
+      `${NEW_REPORT_COL} .task-select`,
+      ".ember-power-select-option",
+      0,
+    );
+  }
+
+  async function setNewDuration(value) {
+    const input = document.querySelector(
+      "input[title='Duration for new report']",
+    );
+    await fillIn(input, value);
+    await triggerEvent(input, "change");
+  }
+
+  test("renders the split report button", async function (assert) {
+    await render(
+      <template><SplitReportModal @report-id={{this.reportId}} /></template>,
+    );
+
+    assert.dom("[data-test-split-report]").hasText("Split Report");
+  });
+
+  test("button is enabled by default", async function (assert) {
+    await render(
+      <template>
+        <ModalTarget />
+        <SplitReportModal @report-id={{this.reportId}} />
+      </template>,
+    );
+
+    assert.dom("[data-test-split-report]").isNotDisabled();
+  });
+
+  test("button is disabled when @disabled is true", async function (assert) {
+    await render(
+      <template>
+        <ModalTarget />
+        <SplitReportModal @report-id={{this.reportId}} @disabled={{true}} />
+      </template>,
+    );
+
+    assert.dom("[data-test-split-report]").isDisabled();
+  });
+
+  test("button shows tooltip when @disabled is true", async function (assert) {
+    await render(
+      <template>
+        <ModalTarget />
+        <SplitReportModal @report-id={{this.reportId}} @disabled={{true}} />
+      </template>,
+    );
+
+    assert
+      .dom("[data-test-split-report]")
+      .hasAttribute(
+        "title",
+        "Only if there is one report selected, and the report is not verified",
+      );
+  });
+
+  test("button has no tooltip when enabled", async function (assert) {
+    await render(
+      <template>
+        <ModalTarget />
+        <SplitReportModal @report-id={{this.reportId}} />
+      </template>,
+    );
+
+    assert.dom("[data-test-split-report]").doesNotHaveAttribute("title");
+  });
+
+  test("modal is not visible initially", async function (assert) {
+    await render(
+      <template>
+        <ModalTarget />
+        <SplitReportModal @report-id={{this.reportId}} />
+      </template>,
+    );
+
+    assert.dom(".modal-header").doesNotExist();
+  });
+
+  test("opens modal on button click", async function (assert) {
+    await render(
+      <template>
+        <ModalTarget />
+        <SplitReportModal @report-id={{this.reportId}} />
+      </template>,
+    );
+
+    await openModal();
+
+    assert.dom(".modal-header h3").hasText("Split Report");
+  });
+
+  test("modal shows two-column layout with original and new report sections", async function (assert) {
+    await render(
+      <template>
+        <ModalTarget />
+        <SplitReportModal @report-id={{this.reportId}} />
+      </template>,
+    );
+
+    await openModal();
+
+    assert.dom(".modal-body").includesText("Original report");
+    assert.dom(".modal-body").includesText("Second Report");
+  });
+
+  test("populates original report comment after opening", async function (assert) {
+    await render(
+      <template>
+        <ModalTarget />
+        <SplitReportModal @report-id={{this.reportId}} />
+      </template>,
+    );
+
+    await openModal();
+
+    assert
+      .dom("[aria-label='Comment for original report']")
+      .hasValue("Original comment");
+  });
+
+  test("new comment input is empty initially", async function (assert) {
+    await render(
+      <template>
+        <ModalTarget />
+        <SplitReportModal @report-id={{this.reportId}} />
+      </template>,
+    );
+
+    await openModal();
+
+    assert.dom("[aria-label='Comment for new report']").hasValue("");
+  });
+
+  test("split button is disabled when no new task is selected", async function (assert) {
+    await render(
+      <template>
+        <ModalTarget />
+        <SplitReportModal @report-id={{this.reportId}} />
+      </template>,
+    );
+
+    await openModal();
+
+    assert.dom(".modal-footer .btn-primary").isDisabled();
+  });
+
+  test("cancel button closes the modal", async function (assert) {
+    await render(
+      <template>
+        <ModalTarget />
+        <SplitReportModal @report-id={{this.reportId}} />
+      </template>,
+    );
+
+    await openModal();
+    assert.dom(".modal-header").exists();
+
+    await click(".modal-footer .btn-default");
+
+    assert.dom(".modal-header").doesNotExist();
+  });
+
+  test("close icon in modal header closes the modal", async function (assert) {
+    await render(
+      <template>
+        <ModalTarget />
+        <SplitReportModal @report-id={{this.reportId}} />
+      </template>,
+    );
+
+    await openModal();
+    assert.dom(".modal-header").exists();
+
+    await click(".modal-header button");
+
+    assert.dom(".modal-header").doesNotExist();
+  });
+
+  test("updating new comment input changes value", async function (assert) {
+    await render(
+      <template>
+        <ModalTarget />
+        <SplitReportModal @report-id={{this.reportId}} />
+      </template>,
+    );
+
+    await openModal();
+    await fillIn("[aria-label='Comment for new report']", "New comment");
+
+    assert.dom("[aria-label='Comment for new report']").hasValue("New comment");
+  });
+
+  test("updating original comment input changes value", async function (assert) {
+    await render(
+      <template>
+        <ModalTarget />
+        <SplitReportModal @report-id={{this.reportId}} />
+      </template>,
+    );
+
+    await openModal();
+    await fillIn(
+      "[aria-label='Comment for original report']",
+      "Updated comment",
+    );
+
+    assert
+      .dom("[aria-label='Comment for original report']")
+      .hasValue("Updated comment");
+  });
+
+  test("comment is reset between openings", async function (assert) {
+    await render(
+      <template>
+        <ModalTarget />
+        <SplitReportModal @report-id={{this.reportId}} />
+      </template>,
+    );
+
+    await openModal();
+    await fillIn("[aria-label='Comment for new report']", "temp comment");
+    await click(".modal-footer .btn-default");
+
+    await openModal();
+
+    assert.dom("[aria-label='Comment for new report']").hasValue("");
+  });
+
+  test("calls split endpoint with old and new report data", async function (assert) {
+    assert.expect(3);
+
+    let capturedBody;
+    this.server.post("/reports/:id/split", (_, { requestBody, params }) => {
+      capturedBody = JSON.parse(requestBody);
+      assert.strictEqual(params.id, String(this.report.id));
+      return { data: {} };
+    });
+
+    await render(
+      <template>
+        <ModalTarget />
+        <SplitReportModal @report-id={{this.reportId}} />
+      </template>,
+    );
+
+    await openModal();
+    await selectNewTask();
+    await setNewDuration("0:30");
+    await click(".modal-footer .btn-primary");
+
+    assert.ok(capturedBody.old_report, "old_report is present in payload");
+    assert.ok(capturedBody.new_report, "new_report is present in payload");
+  });
+
+  test("sends modified old report data to the split endpoint", async function (assert) {
+    assert.expect(2);
+
+    let capturedBody;
+    this.server.post("/reports/:id/split", (_, { requestBody }) => {
+      capturedBody = JSON.parse(requestBody);
+      return { data: {} };
+    });
+
+    await render(
+      <template>
+        <ModalTarget />
+        <SplitReportModal @report-id={{this.reportId}} />
+      </template>,
+    );
+
+    await openModal();
+    await fillIn(
+      "[aria-label='Comment for original report']",
+      "Updated old comment",
+    );
+    await selectNewTask();
+    await setNewDuration("0:30");
+    await click(".modal-footer .btn-primary");
+
+    assert.strictEqual(
+      capturedBody.old_report.comment,
+      "Updated old comment",
+      "sends updated old comment",
+    );
+    assert.strictEqual(
+      capturedBody.old_report.duration,
+      "00:30:00",
+      "old report duration is the remaining time after split",
+    );
+  });
+
+  test("sends new report data to the split endpoint", async function (assert) {
+    assert.expect(2);
+
+    let capturedBody;
+    this.server.post("/reports/:id/split", (_, { requestBody }) => {
+      capturedBody = JSON.parse(requestBody);
+      return { data: {} };
+    });
+
+    await render(
+      <template>
+        <ModalTarget />
+        <SplitReportModal @report-id={{this.reportId}} />
+      </template>,
+    );
+
+    await openModal();
+    await selectNewTask();
+    await fillIn("[aria-label='Comment for new report']", "New report comment");
+    await setNewDuration("0:30");
+    await click(".modal-footer .btn-primary");
+
+    assert.strictEqual(
+      capturedBody.new_report.comment,
+      "New report comment",
+      "sends new report comment",
+    );
+    assert.strictEqual(
+      capturedBody.new_report.duration,
+      "00:30:00",
+      "sends new report duration",
+    );
+  });
+
+  test("closes modal and calls afterSave on successful split", async function (assert) {
+    assert.expect(2);
+
+    let afterSaveCalled = false;
+    this.afterSave = () => {
+      afterSaveCalled = true;
+    };
+
+    await render(
+      <template>
+        <ModalTarget />
+        <SplitReportModal
+          @report-id={{this.reportId}}
+          @afterSave={{this.afterSave}}
+        />
+      </template>,
+    );
+
+    await openModal();
+    await selectNewTask();
+    await setNewDuration("0:30");
+    await click(".modal-footer .btn-primary");
+
+    assert.dom(".modal-header").doesNotExist("modal is closed after split");
+    assert.true(afterSaveCalled, "afterSave is called after successful split");
+  });
+
+  test("shows error notification when split endpoint fails", async function (assert) {
+    this.owner.register(
+      "service:fetch",
+      class extends Service {
+        async fetch() {
+          throw { error: new Error("Internal Server Error") };
+        }
+      },
+    );
+
+    await render(
+      <template>
+        <ModalTarget />
+        <SplitReportModal @report-id={{this.reportId}} />
+      </template>,
+    );
+
+    await openModal();
+    await selectNewTask();
+    await setNewDuration("0:30");
+    await click(".modal-footer .btn-primary");
+
+    assert.dom(".modal-header").exists("modal stays open on error");
+  });
+
+  test("afterSave is not called when split endpoint fails", async function (assert) {
+    this.owner.register(
+      "service:fetch",
+      class extends Service {
+        async fetch() {
+          throw { error: new Error("Internal Server Error") };
+        }
+      },
+    );
+
+    let afterSaveCalled = false;
+    this.afterSave = () => {
+      afterSaveCalled = true;
+    };
+
+    await render(
+      <template>
+        <ModalTarget />
+        <SplitReportModal
+          @report-id={{this.reportId}}
+          @afterSave={{this.afterSave}}
+        />
+      </template>,
+    );
+
+    await openModal();
+    await selectNewTask();
+    await setNewDuration("0:30");
+    await click(".modal-footer .btn-primary");
+
+    assert.false(afterSaveCalled, "afterSave is not called on error");
+  });
+
+  test("afterSave is not called when split is invalid", async function (assert) {
+    assert.expect(2);
+
+    let afterSaveCalled = false;
+    this.afterSave = () => {
+      afterSaveCalled = true;
+    };
+
+    await render(
+      <template>
+        <ModalTarget />
+        <SplitReportModal
+          @report-id={{this.reportId}}
+          @afterSave={{this.afterSave}}
+        />
+      </template>,
+    );
+
+    await openModal();
+
+    assert.dom(".modal-footer .btn-primary").isDisabled();
+    assert.false(afterSaveCalled, "afterSave was not called for invalid split");
+  });
+});


### PR DESCRIPTION
a part of #1121

* [x] split the modal content UI `Original report in the left, and new one in the right`
* [x] rename `new report` to be `Second Report`
* [x] show the label in top of the input
* [x] show the `Task Selection` of the original report
* [x] bring the cancel to `float start`
* [x] split reports for all users who can edit the report
* [x] Automated Tests