### PR TITLE
chore(workflows/frontend): drop codecov

### DIFF
--- a/.github/workflows/frontend.yaml
+++ b/.github/workflows/frontend.yaml
@@ -77,10 +77,3 @@ jobs:
 
       - name: Run tests
         run: pnpm test:ember
-        env:
-          COVERAGE: true
-
-      - name: upload coverage report to codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
-        with:
-          file: ./coverage/lcov.info


### PR DESCRIPTION
I'm not aware of us using this, nor do I know if this works/ever worked, should be safe to drop :)