### PR TITLE
chore: update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,7 +54,10 @@ updates:
       default-days: 7
 
   - package-ecosystem: npm
-    directory: "/ember/ui-core"
+    directories:
+      - /ember
+      - /ember/ui-core
+      - /ember/frontend
     schedule:
       interval: daily
       time: "12:00"
@@ -65,67 +68,3 @@ updates:
       include: scope
     cooldown:
       default-days: 7
-
-  - package-ecosystem: npm
-    directory: "/ember/frontend"
-    schedule:
-      interval: daily
-      time: "12:00"
-      timezone: "Europe/Zurich"
-    open-pull-requests-limit: 20
-    commit-message:
-      prefix: chore
-      include: scope
-    cooldown:
-      default-days: 7
-
-    groups:
-      lint:
-        patterns:
-          - "eslint"
-          - "eslint-*"
-          - "@adfinis/eslint-config"
-
-          - "ember-template-lint"
-          - "ember-template-lint-*"
-
-          - "stylelint"
-          - "stylelint-*"
-
-          - "prettier"
-          - "prettier-*"
-
-      ember-core:
-        patterns:
-          - "ember-cli"
-          - "ember-data"
-          - "ember-source"
-
-      ember:
-        patterns:
-          - "ember-*"
-          - "@ember/*"
-
-        exclude-patterns:
-          - "ember-cli"
-          - "ember-data"
-          - "ember-source"
-
-          - "ember-template-lint"
-          - "ember-template-lint-*"
-          - "ember-auto-import"
-      js:
-        patterns:
-          - "*"
-        exclude-patterns:
-          - "ember-*"
-          - "@ember/*"
-          - "eslint"
-          - "eslint-*"
-          - "@adfinis/eslint-config"
-          - "stylelint"
-          - "stylelint-*"
-          - "ember-auto-import"
-          - "webpack"
-          - "prettier"
-          - "prettier-*"


### PR DESCRIPTION
Instead of separate rules for `/ember/ui-core` & `/ember/frontend`, merge them

(while having them separately is nice, dependabot only updates the `package.json`s and not the lock file, which is suboptimal)