### PR TITLE
fix(frontend): drop ember-fetch

### DIFF
--- a/ember/frontend/ember-cli-build.js
+++ b/ember/frontend/ember-cli-build.js
@@ -35,9 +35,6 @@ module.exports = function (defaults) {
     // sassOptions: {
     //   onlyIncluded: true,
     // },
-    "ember-fetch": {
-      preferNative: true,
-    },
     "ember-simple-auth": {
       useSessionSetupMethod: true,
     },

--- a/ember/frontend/package.json
+++ b/ember/frontend/package.json
@@ -80,7 +80,6 @@
     "ember-data": "5.3.13",
     "ember-decorators": "6.1.1",
     "ember-event-helpers": "^0.1.1",
-    "ember-fetch": "8.1.2",
     "ember-focus-trap": "^1.1.1",
     "ember-in-viewport": "4.1.0",
     "ember-keyboard": "^9.0.1",

--- a/ember/pnpm-lock.yaml
+++ b/ember/pnpm-lock.yaml
@@ -168,9 +168,6 @@ importers:
       ember-event-helpers:
         specifier: ^0.1.1
         version: 0.1.1
-      ember-fetch:
-        specifier: 8.1.2
-        version: 8.1.2
       ember-focus-trap:
         specifier: ^1.1.1
         version: 1.1.1(ember-source@6.4.0(@glimmer/component@1.1.2(@babel/core@7.28.6))(rsvp@4.8.5))


### PR DESCRIPTION
We don't need a polyfill for `fetch` in 2026.