### PR TITLE
chore(backend): fix flaky tests

### DIFF
--- a/backend/timed/factories.py
+++ b/backend/timed/factories.py
@@ -8,7 +8,7 @@ class WorkdayProvider(BaseProvider):
     def workday(self):
         d = self.generator.date_object()
         while d.weekday() >= 5:  # noqa: PLR2004
-            d += timedelta(days=1)
+            d += timedelta(days=1)  # pragma: no cover
         return d
 
 


### PR DESCRIPTION
currently, if the generated date is a weekday, our test suite fails because of the coverage requirement not being met, as we never reach `d += timedelta(days=1)`

this PR fixes that
