### PR TITLE
refactor(backend/tests): use fixtures for factories

### DIFF
--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -9,6 +9,7 @@ from pytest_factoryboy import register
 from rest_framework.test import APIClient
 
 from timed.employment import factories as employment_factories
+from timed.notifications import factories as notifications_factories
 from timed.projects import factories as projects_factories
 from timed.subscription import factories as subscription_factories
 from timed.tracking import factories as tracking_factories
@@ -42,6 +43,8 @@ register(tracking_factories.AbsenceFactory)
 register(tracking_factories.ActivityFactory)
 register(tracking_factories.AttendanceFactory)
 register(tracking_factories.ReportFactory)
+
+register(notifications_factories.NotificationFactory)
 
 
 @pytest.fixture

--- a/backend/conftest.py
+++ b/backend/conftest.py
@@ -81,7 +81,7 @@ def superadmin_user(db):  # noqa: ARG001
 
 
 @pytest.fixture
-def external_employee(db):  # noqa: ARG001
+def external_employee(db, employment_factory):  # noqa: ARG001
     user = get_user_model().objects.create_user(
         username="user",
         password="123qweasd",
@@ -90,12 +90,12 @@ def external_employee(db):  # noqa: ARG001
         is_superuser=False,
         is_staff=False,
     )
-    employment_factories.EmploymentFactory.create(user=user, is_external=True)
+    employment_factory(user=user, is_external=True)
     return user
 
 
 @pytest.fixture
-def internal_employee(db):  # noqa: ARG001
+def internal_employee(db, employment_factory):  # noqa: ARG001
     user = get_user_model().objects.create_user(
         username="user",
         password="123qweasd",
@@ -105,7 +105,7 @@ def internal_employee(db):  # noqa: ARG001
         is_superuser=False,
         is_staff=False,
     )
-    employment_factories.EmploymentFactory.create(user=user, is_external=False)
+    employment_factory(user=user, is_external=False)
     return user
 
 

--- a/backend/timed/employment/tests/test_absence_balance.py
+++ b/backend/timed/employment/tests/test_absence_balance.py
@@ -3,32 +3,29 @@ from datetime import date, timedelta
 from django.urls import reverse
 from rest_framework import status
 
-from timed.employment.factories import (
-    AbsenceCreditFactory,
-    AbsenceTypeFactory,
-    EmploymentFactory,
-    UserFactory,
-)
-from timed.tracking.factories import AbsenceFactory, ReportFactory
 
-
-def test_absence_balance_full_day(auth_client, django_assert_num_queries):
+def test_absence_balance_full_day(
+    auth_client,
+    django_assert_num_queries,
+    absence_credit_factory,
+    absence_factory,
+    absence_type_factory,
+    employment_factory,
+):
     day = date(2017, 2, 28)
 
     user = auth_client.user
-    EmploymentFactory.create(user=user, start_date=day)
-    absence_type = AbsenceTypeFactory.create()
+    employment_factory(user=user, start_date=day)
+    absence_type = absence_type_factory()
 
-    AbsenceCreditFactory.create(date=day, user=user, days=5, absence_type=absence_type)
+    absence_credit_factory(date=day, user=user, days=5, absence_type=absence_type)
 
     # credit on different user, may not show up
-    AbsenceCreditFactory.create(date=date.today(), absence_type=absence_type)
+    absence_credit_factory(date=date.today(), absence_type=absence_type)
 
-    AbsenceFactory.create(date=day, user=user, absence_type=absence_type)
+    absence_factory(date=day, user=user, absence_type=absence_type)
 
-    AbsenceFactory.create(
-        date=day - timedelta(days=1), user=user, absence_type=absence_type
-    )
+    absence_factory(date=day - timedelta(days=1), user=user, absence_type=absence_type)
 
     url = reverse("absence-balance-list")
 
@@ -56,25 +53,27 @@ def test_absence_balance_full_day(auth_client, django_assert_num_queries):
     assert len(json["included"]) == 2
 
 
-def test_absence_balance_fill_worktime(auth_client, django_assert_num_queries):
+def test_absence_balance_fill_worktime(
+    auth_client,
+    django_assert_num_queries,
+    absence_factory,
+    absence_type_factory,
+    employment_factory,
+    report_factory,
+    user_factory,
+):
     day = date(2017, 2, 28)
 
-    user = UserFactory.create()
+    user = user_factory()
     user.supervisors.add(auth_client.user)
-    EmploymentFactory.create(
-        user=user, start_date=day, worktime_per_day=timedelta(hours=5)
-    )
-    absence_type = AbsenceTypeFactory.create(fill_worktime=True)
+    employment_factory(user=user, start_date=day, worktime_per_day=timedelta(hours=5))
+    absence_type = absence_type_factory(fill_worktime=True)
 
-    ReportFactory.create(
-        user=user, date=day + timedelta(days=1), duration=timedelta(hours=4)
-    )
+    report_factory(user=user, date=day + timedelta(days=1), duration=timedelta(hours=4))
 
-    AbsenceFactory.create(
-        date=day + timedelta(days=1), user=user, absence_type=absence_type
-    )
+    absence_factory(date=day + timedelta(days=1), user=user, absence_type=absence_type)
 
-    AbsenceFactory.create(date=day, user=user, absence_type=absence_type)
+    absence_factory(date=day, user=user, absence_type=absence_type)
 
     url = reverse("absence-balance-list")
     with django_assert_num_queries(11):
@@ -100,9 +99,9 @@ def test_absence_balance_fill_worktime(auth_client, django_assert_num_queries):
     assert entry["attributes"]["used-duration"] == "06:00:00"
 
 
-def test_absence_balance_detail(auth_client):
+def test_absence_balance_detail(auth_client, absence_type_factory):
     user = auth_client.user
-    absence_type = AbsenceTypeFactory.create()
+    absence_type = absence_type_factory()
     url = reverse(
         "absence-balance-detail",
         args=[f"{user.id}_{absence_type.id}_2017-03-01"],
@@ -120,10 +119,12 @@ def test_absence_balance_detail(auth_client):
     assert entry["attributes"]["used-duration"] is None
 
 
-def test_absence_balance_list_none_supervisee(auth_client):
+def test_absence_balance_list_none_supervisee(
+    auth_client, absence_type_factory, user_factory
+):
     url = reverse("absence-balance-list")
-    AbsenceTypeFactory.create()
-    unrelated_user = UserFactory.create()
+    absence_type_factory()
+    unrelated_user = user_factory()
 
     result = auth_client.get(
         url, data={"user": unrelated_user.id, "date": "2017-01-03"}
@@ -132,10 +133,12 @@ def test_absence_balance_list_none_supervisee(auth_client):
     assert len(result.json()["data"]) == 0
 
 
-def test_absence_balance_detail_none_supervisee(auth_client):
+def test_absence_balance_detail_none_supervisee(
+    auth_client, absence_type_factory, user_factory
+):
     url = reverse("absence-balance-list")
-    absence_type = AbsenceTypeFactory.create()
-    unrelated_user = UserFactory.create()
+    absence_type = absence_type_factory()
+    unrelated_user = user_factory()
 
     url = reverse(
         "absence-balance-detail",

--- a/backend/timed/employment/tests/test_absence_credit.py
+++ b/backend/timed/employment/tests/test_absence_credit.py
@@ -1,12 +1,6 @@
 from django.urls import reverse
 from rest_framework import status
 
-from timed.employment.factories import (
-    AbsenceCreditFactory,
-    AbsenceTypeFactory,
-    UserFactory,
-)
-
 
 def test_absence_credit_create_authenticated(auth_client):
     url = reverse("absence-credit-list")
@@ -15,8 +9,8 @@ def test_absence_credit_create_authenticated(auth_client):
     assert result.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_absence_credit_create_superuser(superadmin_client):
-    absence_type = AbsenceTypeFactory.create()
+def test_absence_credit_create_superuser(superadmin_client, absence_type_factory):
+    absence_type = absence_type_factory()
 
     url = reverse("absence-credit-list")
 
@@ -38,9 +32,9 @@ def test_absence_credit_create_superuser(superadmin_client):
     assert result.status_code == status.HTTP_201_CREATED
 
 
-def test_absence_credit_get_authenticated(auth_client):
-    AbsenceCreditFactory.create_batch(2)
-    absence_credit = AbsenceCreditFactory.create(user=auth_client.user)
+def test_absence_credit_get_authenticated(auth_client, absence_credit_factory):
+    absence_credit_factory.create_batch(2)
+    absence_credit = absence_credit_factory(user=auth_client.user)
     url = reverse("absence-credit-list")
 
     result = auth_client.get(url)
@@ -50,9 +44,9 @@ def test_absence_credit_get_authenticated(auth_client):
     assert json["data"][0]["id"] == str(absence_credit.id)
 
 
-def test_absence_credit_get_superuser(superadmin_client):
-    AbsenceCreditFactory.create_batch(2)
-    AbsenceCreditFactory.create(user=superadmin_client.user)
+def test_absence_credit_get_superuser(superadmin_client, absence_credit_factory):
+    absence_credit_factory.create_batch(2)
+    absence_credit_factory(user=superadmin_client.user)
     url = reverse("absence-credit-list")
 
     result = superadmin_client.get(url)
@@ -61,13 +55,15 @@ def test_absence_credit_get_superuser(superadmin_client):
     assert len(json["data"]) == 3
 
 
-def test_absence_credit_get_supervisor(auth_client):
-    user = UserFactory.create()
+def test_absence_credit_get_supervisor(
+    auth_client, absence_credit_factory, user_factory
+):
+    user = user_factory()
     auth_client.user.supervisees.add(user)
 
-    AbsenceCreditFactory.create_batch(1)
-    AbsenceCreditFactory.create(user=auth_client.user)
-    AbsenceCreditFactory.create(user=user)
+    absence_credit_factory.create_batch(1)
+    absence_credit_factory(user=auth_client.user)
+    absence_credit_factory(user=user)
     url = reverse("absence-credit-list")
 
     result = auth_client.get(url)

--- a/backend/timed/employment/tests/test_absence_type.py
+++ b/backend/timed/employment/tests/test_absence_type.py
@@ -2,8 +2,6 @@ import pytest
 from django.urls import reverse
 from rest_framework import status
 
-from timed.employment.factories import AbsenceTypeFactory, EmploymentFactory
-
 
 @pytest.mark.parametrize(
     ("is_employed", "is_customer_assignee", "is_customer", "expected"),
@@ -22,6 +20,7 @@ def test_absence_type_list(
     is_customer,
     expected,
     setup_customer_and_employment_status,
+    absence_type_factory,
 ):
     setup_customer_and_employment_status(
         user=auth_client.user,
@@ -30,7 +29,7 @@ def test_absence_type_list(
         is_employed=is_employed,
         is_external=False,
     )
-    AbsenceTypeFactory.create_batch(2)
+    absence_type_factory.create_batch(2)
     url = reverse("absence-type-list")
 
     response = auth_client.get(url)
@@ -40,9 +39,11 @@ def test_absence_type_list(
     assert len(json["data"]) == expected
 
 
-def test_absence_type_list_filter_fill_worktime(internal_employee_client):
-    absence_type = AbsenceTypeFactory.create(fill_worktime=True)
-    AbsenceTypeFactory.create()
+def test_absence_type_list_filter_fill_worktime(
+    internal_employee_client, absence_type_factory
+):
+    absence_type = absence_type_factory(fill_worktime=True)
+    absence_type_factory()
 
     url = reverse("absence-type-list")
 
@@ -61,10 +62,12 @@ def test_absence_type_list_filter_fill_worktime(internal_employee_client):
         (False, status.HTTP_404_NOT_FOUND),
     ],
 )
-def test_absence_type_detail(auth_client, is_employed, expected):
-    absence_type = AbsenceTypeFactory.create()
+def test_absence_type_detail(
+    auth_client, is_employed, expected, absence_type_factory, employment_factory
+):
+    absence_type = absence_type_factory()
     if is_employed:
-        EmploymentFactory.create(user=auth_client.user)
+        employment_factory(user=auth_client.user)
 
     url = reverse("absence-type-detail", args=[absence_type.id])
 
@@ -80,8 +83,8 @@ def test_absence_type_create(auth_client):
     assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
 
 
-def test_absence_type_update(auth_client):
-    absence_type = AbsenceTypeFactory.create()
+def test_absence_type_update(auth_client, absence_type_factory):
+    absence_type = absence_type_factory()
 
     url = reverse("absence-type-detail", args=[absence_type.id])
 
@@ -89,8 +92,8 @@ def test_absence_type_update(auth_client):
     assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
 
 
-def test_absence_type_delete(auth_client):
-    absence_type = AbsenceTypeFactory.create()
+def test_absence_type_delete(auth_client, absence_type_factory):
+    absence_type = absence_type_factory()
 
     url = reverse("absence-type-detail", args=[absence_type.id])
 

--- a/backend/timed/employment/tests/test_employment.py
+++ b/backend/timed/employment/tests/test_employment.py
@@ -6,11 +6,8 @@ import pytest
 from django.urls import reverse
 from rest_framework import status
 
-from timed.employment import factories
 from timed.employment.admin import EmploymentForm
-from timed.employment.factories import EmploymentFactory, LocationFactory, UserFactory
 from timed.employment.models import Employment
-from timed.tracking.factories import ReportFactory
 
 
 def test_employment_create_authenticated(auth_client):
@@ -20,9 +17,9 @@ def test_employment_create_authenticated(auth_client):
     assert result.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_employment_create_superuser(superadmin_client):
+def test_employment_create_superuser(superadmin_client, location_factory):
     url = reverse("employment-list")
-    location = LocationFactory.create()
+    location = location_factory()
 
     data = {
         "data": {
@@ -44,8 +41,8 @@ def test_employment_create_superuser(superadmin_client):
     assert result.status_code == status.HTTP_201_CREATED
 
 
-def test_employment_update_end_before_start(superadmin_client):
-    employment = EmploymentFactory.create(user=superadmin_client.user)
+def test_employment_update_end_before_start(superadmin_client, employment_factory):
+    employment = employment_factory(user=superadmin_client.user)
 
     data = {
         "data": {
@@ -60,10 +57,10 @@ def test_employment_update_end_before_start(superadmin_client):
     assert result.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_employment_update_overlapping(superadmin_client):
+def test_employment_update_overlapping(superadmin_client, employment_factory):
     user = superadmin_client.user
-    EmploymentFactory.create(user=user, end_date=None)
-    employment = EmploymentFactory.create(user=user)
+    employment_factory(user=user, end_date=None)
+    employment = employment_factory(user=user)
 
     data = {
         "data": {
@@ -78,9 +75,9 @@ def test_employment_update_overlapping(superadmin_client):
     assert result.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_employment_list_authenticated(auth_client):
-    EmploymentFactory.create_batch(2)
-    employment = EmploymentFactory.create(user=auth_client.user)
+def test_employment_list_authenticated(auth_client, employment_factory):
+    employment_factory.create_batch(2)
+    employment = employment_factory(user=auth_client.user)
 
     url = reverse("employment-list")
 
@@ -91,9 +88,9 @@ def test_employment_list_authenticated(auth_client):
     assert json["data"][0]["id"] == str(employment.id)
 
 
-def test_employment_list_superuser(superadmin_client):
-    EmploymentFactory.create_batch(2)
-    EmploymentFactory.create(user=superadmin_client.user)
+def test_employment_list_superuser(superadmin_client, employment_factory):
+    employment_factory.create_batch(2)
+    employment_factory(user=superadmin_client.user)
 
     url = reverse("employment-list")
 
@@ -103,11 +100,11 @@ def test_employment_list_superuser(superadmin_client):
     assert len(json["data"]) == 3
 
 
-def test_employment_list_filter_date(auth_client):
-    EmploymentFactory.create(
+def test_employment_list_filter_date(auth_client, employment_factory):
+    employment_factory(
         user=auth_client.user, start_date=date(2017, 1, 1), end_date=date(2017, 4, 1)
     )
-    employment = EmploymentFactory.create(
+    employment = employment_factory(
         user=auth_client.user, start_date=date(2017, 4, 2), end_date=None
     )
 
@@ -120,13 +117,13 @@ def test_employment_list_filter_date(auth_client):
     assert json["data"][0]["id"] == str(employment.id)
 
 
-def test_employment_list_supervisor(auth_client):
-    user = UserFactory.create()
+def test_employment_list_supervisor(auth_client, employment_factory, user_factory):
+    user = user_factory()
     auth_client.user.supervisees.add(user)
 
-    EmploymentFactory.create_batch(1)
-    EmploymentFactory.create(user=auth_client.user)
-    EmploymentFactory.create(user=user)
+    employment_factory.create_batch(1)
+    employment_factory(user=auth_client.user)
+    employment_factory(user=user)
 
     url = reverse("employment-list")
 
@@ -137,11 +134,11 @@ def test_employment_list_supervisor(auth_client):
 
 
 @pytest.mark.django_db
-def test_employment_unique_active():
+def test_employment_unique_active(employment_factory, user_factory):
     """Should only be able to have one active employment per user."""
-    user = UserFactory.create()
-    EmploymentFactory.create(user=user, end_date=None)
-    employment = EmploymentFactory.create(user=user)
+    user = user_factory()
+    employment_factory(user=user, end_date=None)
+    employment = employment_factory(user=user)
     form = EmploymentForm({"end_date": None}, instance=employment)
 
     with pytest.raises(ValueError):  # noqa: PT011
@@ -149,8 +146,8 @@ def test_employment_unique_active():
 
 
 @pytest.mark.django_db
-def test_employment_start_before_end():
-    employment = EmploymentFactory.create()
+def test_employment_start_before_end(employment_factory):
+    employment = employment_factory()
     form = EmploymentForm(
         {"start_date": date(2009, 1, 1), "end_date": date(2016, 1, 1)},
         instance=employment,
@@ -161,10 +158,10 @@ def test_employment_start_before_end():
 
 
 @pytest.mark.django_db
-def test_employment_get_at():
+def test_employment_get_at(employment_factory, user_factory):
     """Should return the right employment on a date."""
-    user = UserFactory.create()
-    employment = EmploymentFactory.create(user=user)
+    user = user_factory()
+    employment = employment_factory(user=user)
 
     assert Employment.objects.get_at(user, employment.start_date) == employment
 
@@ -177,14 +174,16 @@ def test_employment_get_at():
 
 
 @pytest.mark.django_db
-def test_worktime_balance_partial():
+def test_worktime_balance_partial(
+    employment_factory, overtime_credit_factory, public_holiday_factory, report_factory
+):
     """
     Test partial calculation of worktime balance.
 
     Partial is defined as a worktime balance of a time frame
     which is shorter than employment.
     """
-    employment = factories.EmploymentFactory.create(
+    employment = employment_factory(
         start_date=date(2010, 1, 1), end_date=None, worktime_per_day=timedelta(hours=8)
     )
     user = employment.user
@@ -194,22 +193,20 @@ def test_worktime_balance_partial():
     end = date(2017, 3, 26)
 
     # Overtime credit of 10.5 hours
-    factories.OvertimeCreditFactory.create(
+    overtime_credit_factory(
         user=user, date=start, duration=timedelta(hours=10, minutes=30)
     )
 
     # One public holiday during workdays
-    factories.PublicHolidayFactory.create(date=start, location=employment.location)
+    public_holiday_factory(date=start, location=employment.location)
     # One public holiday on weekend
-    factories.PublicHolidayFactory.create(
-        date=start + timedelta(days=1), location=employment.location
-    )
+    public_holiday_factory(date=start + timedelta(days=1), location=employment.location)
     # 5 workdays minus one holiday (32 hours)
     expected_expected = timedelta(hours=32)
 
     # reported 2 days each 10 hours
     for day in range(3, 5):
-        ReportFactory.create(
+        report_factory(
             user=user, date=start + timedelta(days=day), duration=timedelta(hours=10)
         )
     # 10 hours reported time + 10.5 overtime credit
@@ -224,9 +221,11 @@ def test_worktime_balance_partial():
 
 
 @pytest.mark.django_db
-def test_worktime_balance_longer():
+def test_worktime_balance_longer(
+    employment_factory, overtime_credit_factory, public_holiday_factory, report_factory
+):
     """Test calculation of worktime when frame is longer than employment."""
-    employment = factories.EmploymentFactory.create(
+    employment = employment_factory(
         start_date=date(2017, 3, 21),
         end_date=date(2017, 3, 27),
         worktime_per_day=timedelta(hours=8),
@@ -238,34 +237,30 @@ def test_worktime_balance_longer():
     end = date(2017, 12, 31)
 
     # Overtime credit of 10.5 hours before employment
-    factories.OvertimeCreditFactory.create(
+    overtime_credit_factory(
         user=user, date=start, duration=timedelta(hours=10, minutes=30)
     )
     # Overtime credit of during employment
-    factories.OvertimeCreditFactory.create(
+    overtime_credit_factory(
         user=user, date=employment.start_date, duration=timedelta(hours=10, minutes=30)
     )
 
     # One public holiday during employment
-    factories.PublicHolidayFactory.create(
-        date=employment.start_date, location=employment.location
-    )
+    public_holiday_factory(date=employment.start_date, location=employment.location)
     # One public holiday before employment started
-    factories.PublicHolidayFactory.create(
-        date=date(2017, 3, 20), location=employment.location
-    )
+    public_holiday_factory(date=date(2017, 3, 20), location=employment.location)
     # 5 workdays minus one holiday (32 hours)
     expected_expected = timedelta(hours=32)
 
     # reported 2 days each 10 hours
     for day in range(3, 5):
-        ReportFactory.create(
+        report_factory(
             user=user,
             date=employment.start_date + timedelta(days=day),
             duration=timedelta(hours=10),
         )
     # reported time not on current employment
-    ReportFactory.create(user=user, date=date(2017, 1, 5), duration=timedelta(hours=10))
+    report_factory(user=user, date=date(2017, 1, 5), duration=timedelta(hours=10))
     # 10 hours reported time + 10.5 overtime credit
     expected_reported = timedelta(hours=30, minutes=30)
     expected_balance = expected_reported - expected_expected
@@ -278,24 +273,22 @@ def test_worktime_balance_longer():
 
 
 @pytest.mark.django_db
-def test_employment_for_user():
-    user = factories.UserFactory.create()
+def test_employment_for_user(employment_factory, user_factory):
+    user = user_factory()
     # employment overlapping time frame (early start)
-    factories.EmploymentFactory.create(
+    employment_factory(
         start_date=date(2017, 1, 1), end_date=date(2017, 2, 28), user=user
     )
     # employment overlapping time frame (early end)
-    factories.EmploymentFactory.create(
+    employment_factory(
         start_date=date(2017, 3, 1), end_date=date(2017, 3, 31), user=user
     )
     # employment within time frame
-    factories.EmploymentFactory.create(
+    employment_factory(
         start_date=date(2017, 4, 1), end_date=date(2017, 4, 30), user=user
     )
     # employment without end date
-    factories.EmploymentFactory.create(
-        start_date=date(2017, 5, 1), end_date=None, user=user
-    )
+    employment_factory(start_date=date(2017, 5, 1), end_date=None, user=user)
 
     employments = Employment.objects.for_user(user, date(2017, 2, 1), date(2017, 12, 1))
 

--- a/backend/timed/employment/tests/test_location.py
+++ b/backend/timed/employment/tests/test_location.py
@@ -2,8 +2,6 @@ import pytest
 from django.urls import reverse
 from rest_framework import status
 
-from timed.employment.factories import EmploymentFactory, LocationFactory
-
 
 @pytest.mark.django_db
 @pytest.mark.usefixtures("location")
@@ -50,10 +48,12 @@ def test_location_list(
         (False, status.HTTP_404_NOT_FOUND),
     ],
 )
-def test_location_detail(auth_client, is_employed, expected):
-    location = LocationFactory.create()
+def test_location_detail(
+    auth_client, is_employed, expected, employment_factory, location_factory
+):
+    location = location_factory()
     if is_employed:
-        EmploymentFactory.create(user=auth_client.user)
+        employment_factory(user=auth_client.user)
 
     url = reverse("location-detail", args=[location.id])
 
@@ -68,8 +68,8 @@ def test_location_create(auth_client):
     assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
 
 
-def test_location_update(auth_client):
-    location = LocationFactory.create()
+def test_location_update(auth_client, location_factory):
+    location = location_factory()
 
     url = reverse("location-detail", args=[location.id])
 
@@ -77,8 +77,8 @@ def test_location_update(auth_client):
     assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
 
 
-def test_location_delete(auth_client):
-    location = LocationFactory.create()
+def test_location_delete(auth_client, location_factory):
+    location = location_factory()
 
     url = reverse("location-detail", args=[location.id])
 

--- a/backend/timed/employment/tests/test_overtime_credit.py
+++ b/backend/timed/employment/tests/test_overtime_credit.py
@@ -3,8 +3,6 @@
 from django.urls import reverse
 from rest_framework import status
 
-from timed.employment.factories import OvertimeCreditFactory, UserFactory
-
 
 def test_overtime_credit_create_authenticated(auth_client):
     url = reverse("overtime-credit-list")
@@ -31,9 +29,9 @@ def test_overtime_credit_create_superuser(superadmin_client):
     assert result.status_code == status.HTTP_201_CREATED
 
 
-def test_overtime_credit_get_authenticated(auth_client):
-    OvertimeCreditFactory.create_batch(2)
-    overtime_credit = OvertimeCreditFactory.create(user=auth_client.user)
+def test_overtime_credit_get_authenticated(auth_client, overtime_credit_factory):
+    overtime_credit_factory.create_batch(2)
+    overtime_credit = overtime_credit_factory(user=auth_client.user)
     url = reverse("overtime-credit-list")
 
     result = auth_client.get(url)
@@ -43,9 +41,9 @@ def test_overtime_credit_get_authenticated(auth_client):
     assert json["data"][0]["id"] == str(overtime_credit.id)
 
 
-def test_overtime_credit_get_superuser(superadmin_client):
-    OvertimeCreditFactory.create_batch(2)
-    OvertimeCreditFactory.create(user=superadmin_client.user)
+def test_overtime_credit_get_superuser(superadmin_client, overtime_credit_factory):
+    overtime_credit_factory.create_batch(2)
+    overtime_credit_factory(user=superadmin_client.user)
     url = reverse("overtime-credit-list")
 
     result = superadmin_client.get(url)
@@ -54,13 +52,15 @@ def test_overtime_credit_get_superuser(superadmin_client):
     assert len(json["data"]) == 3
 
 
-def test_overtime_credit_get_supervisor(auth_client):
-    user = UserFactory.create()
+def test_overtime_credit_get_supervisor(
+    auth_client, overtime_credit_factory, user_factory
+):
+    user = user_factory()
     auth_client.user.supervisees.add(user)
 
-    OvertimeCreditFactory.create_batch(1)
-    OvertimeCreditFactory.create(user=auth_client.user)
-    OvertimeCreditFactory.create(user=user)
+    overtime_credit_factory.create_batch(1)
+    overtime_credit_factory(user=auth_client.user)
+    overtime_credit_factory(user=user)
     url = reverse("overtime-credit-list")
 
     result = auth_client.get(url)

--- a/backend/timed/employment/tests/test_public_holiday.py
+++ b/backend/timed/employment/tests/test_public_holiday.py
@@ -4,8 +4,6 @@ import pytest
 from django.urls import reverse
 from rest_framework import status
 
-from timed.employment.factories import EmploymentFactory, PublicHolidayFactory
-
 
 @pytest.mark.parametrize(
     ("is_employed", "is_customer_assignee", "is_customer", "expected"),
@@ -24,6 +22,7 @@ def test_public_holiday_list(
     is_customer,
     expected,
     setup_customer_and_employment_status,
+    public_holiday_factory,
 ):
     setup_customer_and_employment_status(
         user=auth_client.user,
@@ -32,7 +31,7 @@ def test_public_holiday_list(
         is_employed=is_employed,
         is_external=False,
     )
-    PublicHolidayFactory.create()
+    public_holiday_factory()
     url = reverse("public-holiday-list")
 
     response = auth_client.get(url)
@@ -49,10 +48,12 @@ def test_public_holiday_list(
         (False, status.HTTP_404_NOT_FOUND),
     ],
 )
-def test_public_holiday_detail(auth_client, is_employed, expected):
-    public_holiday = PublicHolidayFactory.create()
+def test_public_holiday_detail(
+    auth_client, is_employed, expected, employment_factory, public_holiday_factory
+):
+    public_holiday = public_holiday_factory()
     if is_employed:
-        EmploymentFactory.create(user=auth_client.user)
+        employment_factory(user=auth_client.user)
 
     url = reverse("public-holiday-detail", args=[public_holiday.id])
 
@@ -67,8 +68,8 @@ def test_public_holiday_create(auth_client):
     assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
 
 
-def test_public_holiday_update(auth_client):
-    public_holiday = PublicHolidayFactory.create()
+def test_public_holiday_update(auth_client, public_holiday_factory):
+    public_holiday = public_holiday_factory()
 
     url = reverse("public-holiday-detail", args=[public_holiday.id])
 
@@ -76,8 +77,8 @@ def test_public_holiday_update(auth_client):
     assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
 
 
-def test_public_holiday_delete(auth_client):
-    public_holiday = PublicHolidayFactory.create()
+def test_public_holiday_delete(auth_client, public_holiday_factory):
+    public_holiday = public_holiday_factory()
 
     url = reverse("public-holiday-detail", args=[public_holiday.id])
 
@@ -85,9 +86,9 @@ def test_public_holiday_delete(auth_client):
     assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
 
 
-def test_public_holiday_year_filter(internal_employee_client):
-    PublicHolidayFactory.create(date=date(2017, 1, 1))
-    public_holiday = PublicHolidayFactory.create(date=date(2018, 1, 1))
+def test_public_holiday_year_filter(internal_employee_client, public_holiday_factory):
+    public_holiday_factory(date=date(2017, 1, 1))
+    public_holiday = public_holiday_factory(date=date(2018, 1, 1))
 
     url = reverse("public-holiday-list")
 

--- a/backend/timed/employment/tests/test_user.py
+++ b/backend/timed/employment/tests/test_user.py
@@ -4,18 +4,6 @@ import pytest
 from django.urls import reverse
 from rest_framework import status
 
-from timed.employment.factories import (
-    AbsenceTypeFactory,
-    EmploymentFactory,
-    UserFactory,
-)
-from timed.projects.factories import (
-    CustomerAssigneeFactory,
-    ProjectAssigneeFactory,
-    ProjectFactory,
-)
-from timed.tracking.factories import AbsenceFactory, ReportFactory
-
 
 def test_user_list_unauthenticated(client):
     url = reverse("user-list")
@@ -24,16 +12,16 @@ def test_user_list_unauthenticated(client):
 
 
 @pytest.mark.django_db
-def test_user_update_unauthenticated(client):
-    user = UserFactory.create()
+def test_user_update_unauthenticated(client, user_factory):
+    user = user_factory()
     url = reverse("user-detail", args=[user.id])
     response = client.patch(url)
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 
 @pytest.mark.django_db
-def test_user_list(internal_employee_client, django_assert_num_queries):
-    UserFactory.create_batch(2)
+def test_user_list(internal_employee_client, django_assert_num_queries, user_factory):
+    user_factory.create_batch(2)
 
     url = reverse("user-list")
 
@@ -46,8 +34,8 @@ def test_user_list(internal_employee_client, django_assert_num_queries):
     assert len(json["data"]) == 3
 
 
-def test_user_list_external_employee(external_employee_client):
-    UserFactory.create_batch(2)
+def test_user_list_external_employee(external_employee_client, user_factory):
+    user_factory.create_batch(2)
 
     url = reverse("user-list")
 
@@ -116,9 +104,9 @@ def test_user_update_owner(internal_employee_client):
     assert not user.is_staff
 
 
-def test_user_update_other(internal_employee_client):
+def test_user_update_other(internal_employee_client, user_factory):
     """User may not change other user."""
-    user = UserFactory.create()
+    user = user_factory()
     url = reverse("user-detail", args=[user.id])
     res = internal_employee_client.patch(url)
 
@@ -135,10 +123,10 @@ def test_user_delete_authenticated(internal_employee_client):
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_user_delete_superuser(superadmin_client):
+def test_user_delete_superuser(superadmin_client, employment_factory, user_factory):
     """Should not be able delete a user."""
-    user = UserFactory.create()
-    EmploymentFactory.create(user=superadmin_client.user)
+    user = user_factory()
+    employment_factory(user=superadmin_client.user)
 
     url = reverse("user-detail", args=[user.id])
 
@@ -147,11 +135,13 @@ def test_user_delete_superuser(superadmin_client):
 
 
 @pytest.mark.django_db
-def test_user_delete_with_reports_superuser(superadmin_client):
+def test_user_delete_with_reports_superuser(
+    superadmin_client, employment_factory, report_factory, user_factory
+):
     """Test that user with reports may not be deleted."""
-    user = UserFactory.create()
-    ReportFactory.create(user=user)
-    EmploymentFactory.create(user=superadmin_client.user)
+    user = user_factory()
+    report_factory(user=user)
+    employment_factory(user=superadmin_client.user)
 
     url = reverse("user-detail", args=[user.id])
 
@@ -159,11 +149,11 @@ def test_user_delete_with_reports_superuser(superadmin_client):
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_user_supervisor_filter(internal_employee_client):
+def test_user_supervisor_filter(internal_employee_client, user_factory):
     """Should filter users by supervisor."""
-    supervisees = UserFactory.create_batch(5)
+    supervisees = user_factory.create_batch(5)
 
-    UserFactory.create_batch(5)
+    user_factory.create_batch(5)
 
     internal_employee_client.user.supervisees.add(*supervisees)
     internal_employee_client.user.save()
@@ -176,14 +166,20 @@ def test_user_supervisor_filter(internal_employee_client):
 
 
 @pytest.mark.freeze_time("2018-01-07")
-def test_user_transfer(superadmin_client):
-    user = UserFactory.create()
-    EmploymentFactory.create(user=superadmin_client.user)
-    EmploymentFactory.create(user=user, start_date=date(2017, 12, 28), percentage=100)
-    AbsenceTypeFactory.create(fill_worktime=True)
-    AbsenceTypeFactory.create(fill_worktime=False)
-    absence_type = AbsenceTypeFactory.create(fill_worktime=False)
-    AbsenceFactory.create(user=user, absence_type=absence_type, date=date(2017, 12, 29))
+def test_user_transfer(
+    superadmin_client,
+    absence_factory,
+    absence_type_factory,
+    employment_factory,
+    user_factory,
+):
+    user = user_factory()
+    employment_factory(user=superadmin_client.user)
+    employment_factory(user=user, start_date=date(2017, 12, 28), percentage=100)
+    absence_type_factory(fill_worktime=True)
+    absence_type_factory(fill_worktime=False)
+    absence_type = absence_type_factory(fill_worktime=False)
+    absence_factory(user=user, absence_type=absence_type, date=date(2017, 12, 29))
 
     url = reverse("user-transfer", args=[user.id])
     response = superadmin_client.post(url)
@@ -209,13 +205,15 @@ def test_user_transfer(superadmin_client):
 
 
 @pytest.mark.parametrize(("value", "expected"), [(1, 2), (0, 2)])
-def test_user_is_external_filter(internal_employee_client, value, expected):
+def test_user_is_external_filter(
+    internal_employee_client, value, expected, employment_factory, user_factory
+):
     """Should filter users if they have an internal employment."""
-    user = UserFactory.create()
-    user2, user3 = UserFactory.create_batch(2)
-    EmploymentFactory.create(is_external=False, user=user)
-    EmploymentFactory.create(is_external=True, user=user2)
-    EmploymentFactory.create(is_external=True, user=user3)
+    user = user_factory()
+    user2, user3 = user_factory.create_batch(2)
+    employment_factory(is_external=False, user=user)
+    employment_factory(is_external=True, user=user2)
+    employment_factory(is_external=True, user=user3)
 
     response = internal_employee_client.get(
         reverse("user-list"), {"is_external": value}
@@ -224,22 +222,31 @@ def test_user_is_external_filter(internal_employee_client, value, expected):
 
 
 @pytest.mark.parametrize(("value", "expected"), [(1, 1), (0, 4)])
-def test_user_is_reviewer_filter(internal_employee_client, value, expected):
+def test_user_is_reviewer_filter(
+    internal_employee_client,
+    value,
+    expected,
+    project_assignee_factory,
+    project_factory,
+    user_factory,
+):
     """Should filter users if they are a reviewer."""
-    user = UserFactory.create()
-    project = ProjectFactory.create()
-    UserFactory.create_batch(3)
-    ProjectAssigneeFactory.create(user=user, project=project, is_reviewer=True)
+    user = user_factory()
+    project = project_factory()
+    user_factory.create_batch(3)
+    project_assignee_factory(user=user, project=project, is_reviewer=True)
 
     res = internal_employee_client.get(reverse("user-list"), {"is_reviewer": value})
     assert len(res.json()["data"]) == expected
 
 
 @pytest.mark.parametrize(("value", "expected"), [(1, 1), (0, 5)])
-def test_user_is_supervisor_filter(internal_employee_client, value, expected):
+def test_user_is_supervisor_filter(
+    internal_employee_client, value, expected, user_factory
+):
     """Should filter useres if they are a supervisor."""
-    users = UserFactory.create_batch(2)
-    UserFactory.create_batch(3)
+    users = user_factory.create_batch(2)
+    user_factory.create_batch(3)
 
     internal_employee_client.user.supervisees.add(*users)
 
@@ -247,16 +254,18 @@ def test_user_is_supervisor_filter(internal_employee_client, value, expected):
     assert len(res.json()["data"]) == expected
 
 
-def test_user_attributes(internal_employee_client, project):
+def test_user_attributes(
+    internal_employee_client, project, project_assignee_factory, user_factory
+):
     """Should filter users if they are a reviewer."""
-    user = UserFactory.create()
+    user = user_factory()
 
     url = reverse("user-detail", args=[user.id])
 
     res = internal_employee_client.get(url)
     assert not res.json()["data"]["attributes"]["is-reviewer"]
 
-    ProjectAssigneeFactory.create(user=user, project=project, is_reviewer=True)
+    project_assignee_factory(user=user, project=project, is_reviewer=True)
     res = internal_employee_client.get(url)
     assert res.json()["data"]["attributes"]["is-reviewer"]
 
@@ -292,11 +301,18 @@ def test_user_me_anonymous(client):
     ("is_customer", "expected", "status_code"),
     [(True, 1, status.HTTP_200_OK), (False, 0, status.HTTP_403_FORBIDDEN)],
 )
-def test_user_list_no_employment(auth_client, is_customer, expected, status_code):
+def test_user_list_no_employment(
+    auth_client,
+    is_customer,
+    expected,
+    status_code,
+    customer_assignee_factory,
+    user_factory,
+):
     user = auth_client.user
-    UserFactory.create_batch(2)
+    user_factory.create_batch(2)
     if is_customer:
-        CustomerAssigneeFactory.create(user=user, is_customer=True)
+        customer_assignee_factory(user=user, is_customer=True)
 
     url = reverse("user-list")
 

--- a/backend/timed/employment/tests/test_worktime_balance.py
+++ b/backend/timed/employment/tests/test_worktime_balance.py
@@ -5,14 +5,6 @@ from django.urls import reverse
 from django.utils.duration import duration_string
 from rest_framework import status
 
-from timed.employment.factories import (
-    EmploymentFactory,
-    OvertimeCreditFactory,
-    PublicHolidayFactory,
-    UserFactory,
-)
-from timed.tracking.factories import AbsenceFactory, ReportFactory
-
 
 def test_worktime_balance_create(auth_client):
     url = reverse("worktime-balance-list")
@@ -38,18 +30,26 @@ def test_worktime_balance_no_employment(auth_client, django_assert_num_queries):
     assert data["attributes"]["balance"] == "00:00:00"
 
 
-def test_worktime_balance_with_employments(auth_client, django_assert_num_queries):
+def test_worktime_balance_with_employments(
+    auth_client,
+    django_assert_num_queries,
+    absence_factory,
+    employment_factory,
+    overtime_credit_factory,
+    public_holiday_factory,
+    report_factory,
+):
     # Calculate over one week
     start_date = date(2017, 3, 19)
     end_date = date(2017, 3, 26)
 
-    employment = EmploymentFactory.create(
+    employment = employment_factory(
         user=auth_client.user,
         start_date=start_date,
         worktime_per_day=timedelta(hours=8, minutes=30),
         end_date=date(2017, 3, 23),
     )
-    EmploymentFactory.create(
+    employment_factory(
         user=auth_client.user,
         start_date=date(2017, 3, 24),
         worktime_per_day=timedelta(hours=8),
@@ -57,32 +57,32 @@ def test_worktime_balance_with_employments(auth_client, django_assert_num_querie
     )
 
     # Overtime credit of 10 hours
-    OvertimeCreditFactory.create(
+    overtime_credit_factory(
         user=auth_client.user, date=start_date, duration=timedelta(hours=10, minutes=30)
     )
 
     # One public holiday during workdays
-    PublicHolidayFactory.create(date=start_date, location=employment.location)
+    public_holiday_factory(date=start_date, location=employment.location)
     # One public holiday on weekend
-    PublicHolidayFactory.create(
+    public_holiday_factory(
         date=start_date + timedelta(days=1), location=employment.location
     )
 
     # 2x 10 hour reported worktime
-    ReportFactory.create(
+    report_factory(
         user=auth_client.user,
         date=start_date + timedelta(days=3),
         duration=timedelta(hours=10),
     )
 
-    ReportFactory.create(
+    report_factory(
         user=auth_client.user,
         date=start_date + timedelta(days=4),
         duration=timedelta(hours=10),
     )
 
     # one absence
-    AbsenceFactory.create(user=auth_client.user, date=start_date + timedelta(days=5))
+    absence_factory(user=auth_client.user, date=start_date + timedelta(days=5))
 
     url = reverse(
         "worktime-balance-detail",
@@ -127,11 +127,11 @@ def test_worktime_balance_invalid_date(auth_client):
     assert result.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_user_worktime_list_superuser(auth_client):
+def test_user_worktime_list_superuser(auth_client, user_factory):
     auth_client.user.is_superuser = True
     auth_client.user.save()
-    supervisee = UserFactory.create()
-    UserFactory.create()
+    supervisee = user_factory()
+    user_factory()
     auth_client.user.supervisees.add(supervisee)
 
     url = reverse("worktime-balance-list")
@@ -144,9 +144,9 @@ def test_user_worktime_list_superuser(auth_client):
     assert len(json["data"]) == 3
 
 
-def test_worktime_balance_list_supervisor(auth_client):
-    supervisee = UserFactory.create()
-    UserFactory.create()
+def test_worktime_balance_list_supervisor(auth_client, user_factory):
+    supervisee = user_factory()
+    user_factory()
     auth_client.user.supervisees.add(supervisee)
 
     url = reverse("worktime-balance-list")
@@ -159,9 +159,9 @@ def test_worktime_balance_list_supervisor(auth_client):
     assert len(json["data"]) == 2
 
 
-def test_worktime_balance_list_filter_user(auth_client):
-    supervisee = UserFactory.create()
-    UserFactory.create()
+def test_worktime_balance_list_filter_user(auth_client, user_factory):
+    supervisee = user_factory()
+    user_factory()
     auth_client.user.supervisees.add(supervisee)
 
     url = reverse("worktime-balance-list")
@@ -190,24 +190,24 @@ def test_worktime_balance_list_last_reported_date_no_reports(
 
 @pytest.mark.freeze_time("2017-02-02")
 def test_worktime_balance_list_last_reported_date(
-    auth_client, django_assert_num_queries
+    auth_client, django_assert_num_queries, employment_factory, report_factory
 ):
-    EmploymentFactory.create(
+    employment_factory(
         user=auth_client.user,
         start_date=date(2017, 2, 1),
         end_date=date(2017, 2, 2),
         worktime_per_day=timedelta(hours=8),
     )
 
-    ReportFactory.create(
+    report_factory(
         user=auth_client.user, date=date(2017, 2, 1), duration=timedelta(hours=10)
     )
 
     # reports today and in the future should be ignored
-    ReportFactory.create(
+    report_factory(
         user=auth_client.user, date=date(2017, 2, 2), duration=timedelta(hours=10)
     )
-    ReportFactory.create(
+    report_factory(
         user=auth_client.user, date=date(2017, 2, 3), duration=timedelta(hours=10)
     )
 

--- a/backend/timed/notifications/tests/test_budget_check.py
+++ b/backend/timed/notifications/tests/test_budget_check.py
@@ -5,7 +5,6 @@ from django.core.management import call_command
 from django.utils.timezone import now
 from redminelib.exceptions import ResourceNotFoundError
 
-from timed.notifications.factories import NotificationFactory
 from timed.notifications.models import Notification
 from timed.redmine.models import RedmineProject
 
@@ -16,7 +15,12 @@ from timed.redmine.models import RedmineProject
     [(1, 0, 0), (3, 0, 0), (4, 30, 1), (8, 70, 2), (0, 0, 0)],
 )
 def test_budget_check_1(
-    mocker, report_factory, duration, percentage_exceeded, notification_count
+    mocker,
+    report_factory,
+    duration,
+    percentage_exceeded,
+    notification_count,
+    notification_factory,
 ):
     """Test budget check."""
     redmine_instance = mocker.MagicMock()
@@ -36,7 +40,7 @@ def test_budget_check_1(
         report.delete()
 
     if percentage_exceeded == 70:
-        NotificationFactory(
+        notification_factory(
             project=project, notification_type=Notification.BUDGET_CHECK_30
         )
 
@@ -57,7 +61,9 @@ def test_budget_check_1(
 
 
 @pytest.mark.django_db
-def test_budget_check_skip_notification(capsys, mocker, report_factory):
+def test_budget_check_skip_notification(
+    capsys, mocker, report_factory, notification_factory
+):
     redmine_instance = mocker.MagicMock()
     issue = mocker.MagicMock()
     redmine_instance.issue.get.return_value = issue
@@ -71,7 +77,7 @@ def test_budget_check_skip_notification(capsys, mocker, report_factory):
     project.cost_center.name = "DEV_BUILD"
     project.cost_center.save()
 
-    notification = NotificationFactory(
+    notification = notification_factory(
         project=project, notification_type=Notification.BUDGET_CHECK_30, sent_at=now()
     )
 

--- a/backend/timed/notifications/tests/test_notify_changed_employments.py
+++ b/backend/timed/notifications/tests/test_notify_changed_employments.py
@@ -3,22 +3,21 @@ from datetime import date
 import pytest
 from django.core.management import call_command
 
-from timed.employment.factories import EmploymentFactory
 from timed.notifications.models import Notification
 
 
 @pytest.mark.django_db
-def test_notify_changed_employments(mailoutbox, freezer):
+def test_notify_changed_employments(mailoutbox, freezer, employment_factory):
     email = "test@example.net"
 
     # employments changed too far in the past
     freezer.move_to("2017-08-27")
-    EmploymentFactory.create_batch(2)
+    employment_factory.create_batch(2)
 
     # employments which should show up in report
     freezer.move_to("2017-09-03")
-    finished = EmploymentFactory.create(end_date=date(2017, 10, 10), percentage=80)
-    new = EmploymentFactory.create(percentage=100)
+    finished = employment_factory(end_date=date(2017, 10, 10), percentage=80)
+    new = employment_factory(percentage=100)
 
     freezer.move_to("2017-09-04")
     call_command("notify_changed_employments", email=email)

--- a/backend/timed/notifications/tests/test_notify_reviewers_unverified.py
+++ b/backend/timed/notifications/tests/test_notify_reviewers_unverified.py
@@ -3,15 +3,7 @@ from datetime import date
 import pytest
 from django.core.management import call_command
 
-from timed.employment.factories import UserFactory
 from timed.notifications.models import Notification
-from timed.projects.factories import (
-    ProjectAssigneeFactory,
-    ProjectFactory,
-    TaskAssigneeFactory,
-    TaskFactory,
-)
-from timed.tracking.factories import ReportFactory
 
 
 @pytest.mark.django_db
@@ -25,25 +17,32 @@ from timed.tracking.factories import ReportFactory
         ("", "This is a test"),
     ],
 )
-def test_notify_reviewers_with_cc_and_message(mailoutbox, cc, message):
+def test_notify_reviewers_with_cc_and_message(
+    mailoutbox,
+    cc,
+    message,
+    project_assignee_factory,
+    project_factory,
+    report_factory,
+    task_factory,
+    user_factory,
+):
     """Test time range 2017-7-1 till 2017-7-31."""
     # a reviewer which will be notified
-    reviewer_work = UserFactory.create()
-    project_work = ProjectFactory.create()
-    ProjectAssigneeFactory.create(
-        user=reviewer_work, project=project_work, is_reviewer=True
-    )
-    task_work = TaskFactory.create(project=project_work)
-    ReportFactory.create(date=date(2017, 7, 1), task=task_work, verified_by=None)
+    reviewer_work = user_factory()
+    project_work = project_factory()
+    project_assignee_factory(user=reviewer_work, project=project_work, is_reviewer=True)
+    task_work = task_factory(project=project_work)
+    report_factory(date=date(2017, 7, 1), task=task_work, verified_by=None)
 
     # a reviewer which doesn't have any unverified reports
-    reviewer_no_work = UserFactory.create()
-    project_no_work = ProjectFactory.create()
-    ProjectAssigneeFactory.create(
+    reviewer_no_work = user_factory()
+    project_no_work = project_factory()
+    project_assignee_factory(
         user=reviewer_no_work, project=project_no_work, is_reviewer=True
     )
-    task_no_work = TaskFactory.create(project=project_no_work)
-    ReportFactory.create(
+    task_no_work = task_factory(project=project_no_work)
+    report_factory(
         date=date(2017, 7, 1), task=task_no_work, verified_by=reviewer_no_work
     )
 
@@ -65,16 +64,21 @@ def test_notify_reviewers_with_cc_and_message(mailoutbox, cc, message):
 
 @pytest.mark.django_db
 @pytest.mark.freeze_time("2017-8-4")
-def test_notify_reviewers(mailoutbox):
+def test_notify_reviewers(
+    mailoutbox,
+    project_assignee_factory,
+    project_factory,
+    report_factory,
+    task_factory,
+    user_factory,
+):
     """Test time range 2017-7-1 till 2017-7-31."""
     # a reviewer which will be notified
-    reviewer_work = UserFactory.create()
-    project_work = ProjectFactory.create()
-    ProjectAssigneeFactory.create(
-        user=reviewer_work, project=project_work, is_reviewer=True
-    )
-    task_work = TaskFactory.create(project=project_work)
-    ReportFactory.create(date=date(2017, 7, 1), task=task_work, verified_by=None)
+    reviewer_work = user_factory()
+    project_work = project_factory()
+    project_assignee_factory(user=reviewer_work, project=project_work, is_reviewer=True)
+    task_work = task_factory(project=project_work)
+    report_factory(date=date(2017, 7, 1), task=task_work, verified_by=None)
 
     call_command("notify_reviewers_unverified")
 
@@ -89,23 +93,29 @@ def test_notify_reviewers(mailoutbox):
 
 @pytest.mark.django_db
 @pytest.mark.freeze_time("2017-8-4")
-def test_notify_reviewers_reviewer_hierarchy(mailoutbox):
+def test_notify_reviewers_reviewer_hierarchy(
+    mailoutbox,
+    project_assignee_factory,
+    project_factory,
+    report_factory,
+    task_assignee_factory,
+    task_factory,
+    user_factory,
+):
     """Test notification with reviewer hierarchy.
 
     Test if only the lowest in reviewer hierarchy gets notified.
     """
     # user that shouldn't be notified
-    project_reviewer = UserFactory.create()
+    project_reviewer = user_factory()
     # user that should be notified
-    task_reviewer = UserFactory.create()
-    project = ProjectFactory.create()
-    task = TaskFactory.create(project=project)
-    ProjectAssigneeFactory.create(
-        user=project_reviewer, project=project, is_reviewer=True
-    )
-    TaskAssigneeFactory.create(user=task_reviewer, task=task, is_reviewer=True)
+    task_reviewer = user_factory()
+    project = project_factory()
+    task = task_factory(project=project)
+    project_assignee_factory(user=project_reviewer, project=project, is_reviewer=True)
+    task_assignee_factory(user=task_reviewer, task=task, is_reviewer=True)
 
-    ReportFactory.create(date=date(2017, 7, 1), task=task, verified_by=None)
+    report_factory(date=date(2017, 7, 1), task=task, verified_by=None)
 
     call_command("notify_reviewers_unverified")
 

--- a/backend/timed/notifications/tests/test_notify_supervisors_shorttime.py
+++ b/backend/timed/notifications/tests/test_notify_supervisors_shorttime.py
@@ -4,23 +4,22 @@ import pytest
 from dateutil.rrule import DAILY, FR, MO, rrule
 from django.core.management import call_command
 
-from timed.employment.factories import EmploymentFactory, UserFactory
 from timed.notifications.models import Notification
-from timed.projects.factories import TaskFactory
-from timed.tracking.factories import ReportFactory
 
 
 @pytest.mark.django_db
 @pytest.mark.freeze_time("2017-7-27")
-def test_notify_supervisors(mailoutbox):
+def test_notify_supervisors(
+    mailoutbox, employment_factory, report_factory, task_factory, user_factory
+):
     """Test time range 2017-7-17 till 2017-7-23."""
     start = date(2017, 7, 14)
     # supervisee with short time
-    supervisee = UserFactory.create()
-    supervisor = UserFactory.create()
+    supervisee = user_factory()
+    supervisor = user_factory()
     supervisee.supervisors.add(supervisor)
 
-    EmploymentFactory.create(user=supervisee, start_date=start, percentage=100)
+    employment_factory(user=supervisee, start_date=start, percentage=100)
     workdays = rrule(
         DAILY,
         dtstart=start,
@@ -28,11 +27,9 @@ def test_notify_supervisors(mailoutbox):
         # range is excluding last
         byweekday=range(MO.weekday, FR.weekday + 1),
     )
-    task = TaskFactory.create()
+    task = task_factory()
     for dt in workdays:
-        ReportFactory.create(
-            user=supervisee, date=dt, task=task, duration=timedelta(hours=7)
-        )
+        report_factory(user=supervisee, date=dt, task=task, duration=timedelta(hours=7))
 
     call_command("notify_supervisors_shorttime")
 
@@ -50,10 +47,10 @@ def test_notify_supervisors(mailoutbox):
 
 
 @pytest.mark.django_db
-def test_notify_supervisors_no_employment(mailoutbox):
+def test_notify_supervisors_no_employment(mailoutbox, user_factory):
     """Check that supervisees without employment do not notify supervisor."""
-    supervisee = UserFactory.create()
-    supervisor = UserFactory.create()
+    supervisee = user_factory()
+    supervisor = user_factory()
     supervisee.supervisors.add(supervisor)
 
     call_command("notify_supervisors_shorttime")

--- a/backend/timed/projects/tests/test_billing_type.py
+++ b/backend/timed/projects/tests/test_billing_type.py
@@ -2,7 +2,7 @@ import pytest
 from django.urls import reverse
 from rest_framework.status import HTTP_200_OK, HTTP_403_FORBIDDEN
 
-from timed.projects import factories, models
+from timed.projects import models
 
 
 @pytest.mark.parametrize(
@@ -39,6 +39,8 @@ def test_billing_type_list(
     expected,
     status_code,
     setup_customer_and_employment_status,
+    customer_factory,
+    project_factory,
 ):
     user = auth_client.user
     setup_customer_and_employment_status(
@@ -51,10 +53,8 @@ def test_billing_type_list(
     if is_customer_assignee:
         customer = models.Customer.objects.get(customer_assignees__user=user)
     else:
-        customer = factories.CustomerFactory.create()
-    project = factories.ProjectFactory.create(
-        customer_visible=customer_visible, customer=customer
-    )
+        customer = customer_factory()
+    project = project_factory(customer_visible=customer_visible, customer=customer)
 
     url = reverse("billing-type-list")
 

--- a/backend/timed/projects/tests/test_cost_center.py
+++ b/backend/timed/projects/tests/test_cost_center.py
@@ -2,8 +2,6 @@ import pytest
 from django.urls import reverse
 from rest_framework.status import HTTP_200_OK, HTTP_403_FORBIDDEN
 
-from timed.projects.factories import CostCenterFactory
-
 
 @pytest.mark.parametrize(
     ("is_employed", "is_customer_assignee", "is_customer", "status_code"),
@@ -22,9 +20,10 @@ def test_cost_center_list(
     is_customer,
     status_code,
     setup_customer_and_employment_status,
+    cost_center_factory,
 ):
     user = auth_client.user
-    cost_center = CostCenterFactory.create()
+    cost_center = cost_center_factory()
     setup_customer_and_employment_status(
         user=user,
         is_assignee=is_customer_assignee,

--- a/backend/timed/projects/tests/test_customer.py
+++ b/backend/timed/projects/tests/test_customer.py
@@ -4,12 +4,10 @@ import pytest
 from django.urls import reverse
 from rest_framework import status
 
-from timed.projects.factories import CustomerAssigneeFactory, CustomerFactory
 
-
-def test_customer_list_not_archived(internal_employee_client):
-    CustomerFactory.create(archived=True)
-    customer = CustomerFactory.create(archived=False)
+def test_customer_list_not_archived(internal_employee_client, customer_factory):
+    customer_factory(archived=True)
+    customer = customer_factory(archived=False)
 
     url = reverse("customer-list")
 
@@ -21,8 +19,8 @@ def test_customer_list_not_archived(internal_employee_client):
     assert json["data"][0]["id"] == str(customer.id)
 
 
-def test_customer_detail(internal_employee_client):
-    customer = CustomerFactory.create()
+def test_customer_detail(internal_employee_client, customer_factory):
+    customer = customer_factory()
 
     url = reverse("customer-detail", args=[customer.id])
 
@@ -37,8 +35,8 @@ def test_customer_create(auth_client):
     assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
 
 
-def test_customer_update(auth_client):
-    customer = CustomerFactory.create()
+def test_customer_update(auth_client, customer_factory):
+    customer = customer_factory()
 
     url = reverse("customer-detail", args=[customer.id])
 
@@ -46,8 +44,8 @@ def test_customer_update(auth_client):
     assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
 
 
-def test_customer_delete(auth_client):
-    customer = CustomerFactory.create()
+def test_customer_delete(auth_client, customer_factory):
+    customer = customer_factory()
 
     url = reverse("customer-detail", args=[customer.id])
 
@@ -57,10 +55,10 @@ def test_customer_delete(auth_client):
 
 @pytest.mark.parametrize(("is_assigned", "expected"), [(True, 1), (False, 0)])
 def test_customer_list_external_employee(
-    external_employee_client, is_assigned, expected
+    external_employee_client, is_assigned, expected, customer_factory
 ):
-    CustomerFactory.create_batch(4)
-    customer = CustomerFactory.create()
+    customer_factory.create_batch(4)
+    customer = customer_factory()
     if is_assigned:
         customer.assignees.add(external_employee_client.user)
 
@@ -77,11 +75,13 @@ def test_customer_list_external_employee(
     ("is_customer", "expected"),
     [(True, 1), (False, 0)],
 )
-def test_customer_list_no_employment(auth_client, is_customer, expected):
-    CustomerFactory.create_batch(4)
-    customer = CustomerFactory.create()
+def test_customer_list_no_employment(
+    auth_client, is_customer, expected, customer_assignee_factory, customer_factory
+):
+    customer_factory.create_batch(4)
+    customer = customer_factory()
     if is_customer:
-        CustomerAssigneeFactory.create(
+        customer_assignee_factory(
             user=auth_client.user, is_customer=True, customer=customer
         )
 

--- a/backend/timed/projects/tests/test_customer_assignee.py
+++ b/backend/timed/projects/tests/test_customer_assignee.py
@@ -2,8 +2,6 @@ import pytest
 from django.urls import reverse
 from rest_framework.status import HTTP_200_OK
 
-from timed.projects.factories import CustomerAssigneeFactory
-
 
 @pytest.mark.parametrize(
     ("is_employed", "is_external", "is_customer_assignee", "is_customer", "expected"),
@@ -26,8 +24,9 @@ def test_customer_assignee_list(
     is_customer,
     expected,
     setup_customer_and_employment_status,
+    customer_assignee_factory,
 ):
-    customer_assignee = CustomerAssigneeFactory.create()
+    customer_assignee = customer_assignee_factory()
     user = auth_client.user
     setup_customer_and_employment_status(
         user=user,

--- a/backend/timed/projects/tests/test_project.py
+++ b/backend/timed/projects/tests/test_project.py
@@ -6,20 +6,12 @@ import pytest
 from django.urls import reverse
 from rest_framework import status
 
-from timed.employment.factories import UserFactory
-from timed.projects.factories import (
-    CustomerAssigneeFactory,
-    ProjectAssigneeFactory,
-    ProjectFactory,
-    TaskAssigneeFactory,
-    TaskFactory,
-)
 from timed.projects.serializers import ProjectSerializer
 
 
-def test_project_list_not_archived(internal_employee_client):
-    project = ProjectFactory.create(archived=False)
-    ProjectFactory.create(archived=True)
+def test_project_list_not_archived(internal_employee_client, project_factory):
+    project = project_factory(archived=False)
+    project_factory(archived=True)
 
     url = reverse("project-list")
 
@@ -32,10 +24,14 @@ def test_project_list_not_archived(internal_employee_client):
 
 
 def test_project_list_include(
-    internal_employee_client, django_assert_num_queries, project
+    internal_employee_client,
+    django_assert_num_queries,
+    project,
+    project_assignee_factory,
+    user_factory,
 ):
-    user = UserFactory.create()
-    ProjectAssigneeFactory.create(user=user, project=project, is_reviewer=True)
+    user = user_factory()
+    project_assignee_factory(user=user, project=project, is_reviewer=True)
 
     url = reverse("project-list")
 
@@ -119,10 +115,10 @@ def test_project_delete(auth_client, project):
 
 @pytest.mark.parametrize(("is_assigned", "expected"), [(True, 1), (False, 0)])
 def test_project_list_external_employee(
-    external_employee_client, is_assigned, expected
+    external_employee_client, is_assigned, expected, project_factory
 ):
-    ProjectFactory.create_batch(4)
-    project = ProjectFactory.create()
+    project_factory.create_batch(4)
+    project = project_factory()
     if is_assigned:
         project.assignees.add(external_employee_client.user)
 
@@ -135,11 +131,13 @@ def test_project_list_external_employee(
     assert len(json["data"]) == expected
 
 
-def test_project_filter(internal_employee_client):
+def test_project_filter(
+    internal_employee_client, project_assignee_factory, project_factory
+):
     user = internal_employee_client.user
-    proj1, _proj2, *_ = ProjectFactory.create_batch(4)
-    ProjectAssigneeFactory.create(project=proj1, user=user, is_reviewer=True)
-    ProjectAssigneeFactory.create(project=proj1, user=user, is_manager=True)
+    proj1, _proj2, *_ = project_factory.create_batch(4)
+    project_assignee_factory(project=proj1, user=user, is_reviewer=True)
+    project_assignee_factory(project=proj1, user=user, is_manager=True)
 
     url = reverse("project-list")
 
@@ -156,8 +154,8 @@ def test_project_filter(internal_employee_client):
     assert len(json["data"]) == 1
 
 
-def test_project_multi_number_value_filter(internal_employee_client):
-    proj1, proj2, *_ = ProjectFactory.create_batch(4)
+def test_project_multi_number_value_filter(internal_employee_client, project_factory):
+    proj1, proj2, *_ = project_factory.create_batch(4)
 
     url = reverse("project-list")
 
@@ -172,7 +170,7 @@ def test_project_multi_number_value_filter(internal_employee_client):
 
 @pytest.mark.usefixtures("internal_employee_client")
 def test_project_update_billed_flag(report_factory):
-    report = report_factory.create()
+    report = report_factory()
     project = report.task.project
     assert not report.billed
 
@@ -198,10 +196,17 @@ def test_project_update_billed_flag(report_factory):
         (False, False, 0),
     ],
 )
-def test_project_list_no_employment(auth_client, project, is_customer, expected):
-    ProjectFactory.create_batch(4)
+def test_project_list_no_employment(
+    auth_client,
+    project,
+    is_customer,
+    expected,
+    customer_assignee_factory,
+    project_factory,
+):
+    project_factory.create_batch(4)
     if is_customer:
-        CustomerAssigneeFactory.create(
+        customer_assignee_factory(
             user=auth_client.user, is_customer=True, customer=project.customer
         )
 
@@ -224,19 +229,25 @@ def test_project_list_no_employment(auth_client, project, is_customer, expected)
     ],
 )
 def test_project_activate_remaining_effort(
-    internal_employee_client, assignee_level, status_code
+    internal_employee_client,
+    assignee_level,
+    status_code,
+    customer_assignee_factory,
+    project_assignee_factory,
+    task_assignee_factory,
+    task_factory,
 ):
-    task = TaskFactory.create()
+    task = task_factory()
     user = internal_employee_client.user
 
     if assignee_level == "customer":
-        CustomerAssigneeFactory(
+        customer_assignee_factory(
             user=user, customer=task.project.customer, is_manager=True
         )
     elif assignee_level == "project":
-        ProjectAssigneeFactory(user=user, project=task.project, is_manager=True)
+        project_assignee_factory(user=user, project=task.project, is_manager=True)
     elif assignee_level == "task":
-        TaskAssigneeFactory(user=user, task=task, is_manager=True)
+        task_assignee_factory(user=user, task=task, is_manager=True)
 
     data = {
         "data": {

--- a/backend/timed/projects/tests/test_project_assignee.py
+++ b/backend/timed/projects/tests/test_project_assignee.py
@@ -2,8 +2,6 @@ import pytest
 from django.urls import reverse
 from rest_framework.status import HTTP_200_OK
 
-from timed.projects.factories import ProjectAssigneeFactory
-
 
 @pytest.mark.parametrize(
     ("is_employed", "is_external", "is_customer_assignee", "is_customer", "expected"),
@@ -26,6 +24,7 @@ def test_project_assignee_list(
     is_customer,
     expected,
     setup_customer_and_employment_status,
+    project_assignee_factory,
 ):
     user = auth_client.user
     setup_customer_and_employment_status(
@@ -35,7 +34,7 @@ def test_project_assignee_list(
         is_employed=is_employed,
         is_external=is_external,
     )
-    project_assignee = ProjectAssigneeFactory.create()
+    project_assignee = project_assignee_factory()
     url = reverse("project-assignee-list")
 
     res = auth_client.get(url)

--- a/backend/timed/projects/tests/test_task.py
+++ b/backend/timed/projects/tests/test_task.py
@@ -6,13 +6,6 @@ import pytest
 from django.urls import reverse
 from rest_framework import status
 
-from timed.employment.factories import EmploymentFactory
-from timed.projects.factories import (
-    CustomerAssigneeFactory,
-    ProjectFactory,
-    TaskFactory,
-)
-
 
 def test_task_list_not_archived(internal_employee_client, task_factory):
     task = task_factory(archived=False)
@@ -129,15 +122,22 @@ def test_task_create(
     ],
 )
 def test_task_update(
-    auth_client, task, task_assignee, project_assignee, different_project, expected
+    auth_client,
+    task,
+    task_assignee,
+    project_assignee,
+    different_project,
+    expected,
+    employment_factory,
+    project_factory,
 ):
     user = auth_client.user
-    EmploymentFactory.create(user=user)
+    employment_factory(user=user)
     task_assignee.task = task
     task_assignee.user = user
     task_assignee.save()
     if different_project:
-        project = ProjectFactory.create()
+        project = project_factory()
         project_assignee.project = project
     project_assignee.user = user
     project_assignee.save()
@@ -169,12 +169,12 @@ def test_task_update(
         (False, False, True, status.HTTP_403_FORBIDDEN),
     ],
 )
-def test_task_delete(auth_client, task, project_assignee, expected):
+def test_task_delete(auth_client, task, project_assignee, expected, employment_factory):
     user = auth_client.user
     project_assignee.project = task.project
     project_assignee.user = user
     project_assignee.save()
-    EmploymentFactory.create(user=user)
+    employment_factory(user=user)
 
     url = reverse("task-detail", args=[task.id])
 
@@ -209,9 +209,11 @@ def test_task_detail_with_reports(internal_employee_client, task, report_factory
 
 
 @pytest.mark.parametrize(("is_assigned", "expected"), [(True, 1), (False, 0)])
-def test_task_list_external_employee(external_employee_client, is_assigned, expected):
-    TaskFactory.create_batch(4)
-    task = TaskFactory.create()
+def test_task_list_external_employee(
+    external_employee_client, is_assigned, expected, task_factory
+):
+    task_factory.create_batch(4)
+    task = task_factory()
     if is_assigned:
         task.assignees.add(external_employee_client.user)
 
@@ -233,11 +235,18 @@ def test_task_list_external_employee(external_employee_client, is_assigned, expe
         (False, True, 0),
     ],
 )
-def test_task_list_no_employment(auth_client, is_customer, customer_visible, expected):
-    TaskFactory.create_batch(4)
-    task = TaskFactory.create()
+def test_task_list_no_employment(
+    auth_client,
+    is_customer,
+    customer_visible,
+    expected,
+    customer_assignee_factory,
+    task_factory,
+):
+    task_factory.create_batch(4)
+    task = task_factory()
     if is_customer:
-        CustomerAssigneeFactory.create(
+        customer_assignee_factory(
             user=auth_client.user, is_customer=True, customer=task.project.customer
         )
     if customer_visible:
@@ -253,8 +262,8 @@ def test_task_list_no_employment(auth_client, is_customer, customer_visible, exp
     assert len(json["data"]) == expected
 
 
-def test_task_multi_number_value_filter(internal_employee_client):
-    task1, task2, *_ = TaskFactory.create_batch(4)
+def test_task_multi_number_value_filter(internal_employee_client, task_factory):
+    task1, task2, *_ = task_factory.create_batch(4)
 
     url = reverse("task-list")
 
@@ -268,7 +277,7 @@ def test_task_multi_number_value_filter(internal_employee_client):
 
 
 def test_task_detail_spent_billable(internal_employee_client, task, report_factory):
-    report_factory.create(task=task, duration=timedelta(minutes=30), not_billable=True)
+    report_factory(task=task, duration=timedelta(minutes=30), not_billable=True)
 
     url = reverse("task-detail", args=[task.id])
 

--- a/backend/timed/projects/tests/test_task_assignee.py
+++ b/backend/timed/projects/tests/test_task_assignee.py
@@ -2,8 +2,6 @@ import pytest
 from django.urls import reverse
 from rest_framework.status import HTTP_200_OK
 
-from timed.projects.factories import TaskAssigneeFactory
-
 
 @pytest.mark.parametrize(
     ("is_employed", "is_external", "is_customer_assignee", "is_customer", "expected"),
@@ -26,6 +24,7 @@ def test_task_assignee_list(
     is_customer,
     expected,
     setup_customer_and_employment_status,
+    task_assignee_factory,
 ):
     user = auth_client.user
     setup_customer_and_employment_status(
@@ -35,7 +34,7 @@ def test_task_assignee_list(
         is_employed=is_employed,
         is_external=is_external,
     )
-    task_assignee = TaskAssigneeFactory.create()
+    task_assignee = task_assignee_factory()
     url = reverse("task-assignee-list")
 
     res = auth_client.get(url)

--- a/backend/timed/reports/tests/test_customer_statistic.py
+++ b/backend/timed/reports/tests/test_customer_statistic.py
@@ -4,10 +4,6 @@ import pytest
 from django.urls import reverse
 from rest_framework import status
 
-from timed.employment.factories import EmploymentFactory, UserFactory
-from timed.projects.factories import CostCenterFactory, TaskAssigneeFactory, TaskFactory
-from timed.tracking.factories import ReportFactory
-
 
 @pytest.mark.parametrize(
     ("is_employed", "is_customer_assignee", "is_customer", "expected", "status_code"),
@@ -28,6 +24,7 @@ def test_customer_statistic_list(
     status_code,
     django_assert_num_queries,
     setup_customer_and_employment_status,
+    report_factory,
 ):
     user = auth_client.user
 
@@ -44,9 +41,9 @@ def test_customer_statistic_list(
     # list as well
     third_customer = assignee.customer if assignee else None
 
-    report = ReportFactory.create(duration=timedelta(hours=1))
-    ReportFactory.create(duration=timedelta(hours=2), task=report.task)
-    report2 = ReportFactory.create(duration=timedelta(hours=4))
+    report = report_factory(duration=timedelta(hours=1))
+    report_factory(duration=timedelta(hours=2), task=report.task)
+    report2 = report_factory(duration=timedelta(hours=4))
 
     url = reverse("customer-statistic-list")
     with django_assert_num_queries(expected):
@@ -95,6 +92,11 @@ def test_customer_statistic_filtered(
     filter,  # noqa: A002
     expected_result,
     setup_customer_and_employment_status,
+    cost_center_factory,
+    report_factory,
+    task_assignee_factory,
+    task_factory,
+    user_factory,
 ):
     user = auth_client.user
     setup_customer_and_employment_status(
@@ -105,14 +107,16 @@ def test_customer_statistic_filtered(
         is_external=False,
     )
 
-    cost_center = CostCenterFactory()
-    task_z = TaskFactory.create(name="Z", cost_center=cost_center)
-    task_test = TaskFactory.create(name="Test")
-    reviewer = TaskAssigneeFactory(user=UserFactory(), task=task_test, is_reviewer=True)
+    cost_center = cost_center_factory()
+    task_z = task_factory(name="Z", cost_center=cost_center)
+    task_test = task_factory(name="Test")
+    reviewer = task_assignee_factory(
+        user=user_factory(), task=task_test, is_reviewer=True
+    )
 
-    ReportFactory.create(duration=timedelta(hours=1), date="2022-08-05", task=task_test)
-    ReportFactory.create(duration=timedelta(hours=2), date="2022-08-30", task=task_test)
-    ReportFactory.create(duration=timedelta(hours=3), date="2022-09-01", task=task_z)
+    report_factory(duration=timedelta(hours=1), date="2022-08-05", task=task_test)
+    report_factory(duration=timedelta(hours=2), date="2022-08-30", task=task_test)
+    report_factory(duration=timedelta(hours=3), date="2022-09-01", task=task_z)
 
     filter_values = {
         "from_date": "2022-08-20",  # last two reports
@@ -142,11 +146,17 @@ def test_customer_statistic_filtered(
     ],
 )
 def test_customer_statistic_detail(
-    auth_client, is_employed, expected, status_code, django_assert_num_queries
+    auth_client,
+    is_employed,
+    expected,
+    status_code,
+    django_assert_num_queries,
+    employment_factory,
+    report_factory,
 ):
     if is_employed:
-        EmploymentFactory.create(user=auth_client.user)
-    report = ReportFactory.create(duration=timedelta(hours=1))
+        employment_factory(user=auth_client.user)
+    report = report_factory(duration=timedelta(hours=1))
 
     url = reverse("customer-statistic-detail", args=[report.task.project.customer.id])
     with django_assert_num_queries(expected):

--- a/backend/timed/reports/tests/test_month_statistic.py
+++ b/backend/timed/reports/tests/test_month_statistic.py
@@ -4,8 +4,6 @@ import pytest
 from django.urls import reverse
 from rest_framework import status
 
-from timed.tracking.factories import ReportFactory
-
 
 @pytest.mark.parametrize(
     ("is_employed", "is_customer_assignee", "is_customer", "expected"),
@@ -24,6 +22,7 @@ def test_month_statistic_list(
     is_customer,
     expected,
     setup_customer_and_employment_status,
+    report_factory,
 ):
     user = auth_client.user
     setup_customer_and_employment_status(
@@ -34,9 +33,9 @@ def test_month_statistic_list(
         is_external=False,
     )
 
-    ReportFactory.create(duration=timedelta(hours=1), date=date(2016, 1, 1))
-    ReportFactory.create(duration=timedelta(hours=1), date=date(2015, 12, 4))
-    ReportFactory.create(duration=timedelta(hours=2), date=date(2015, 12, 31))
+    report_factory(duration=timedelta(hours=1), date=date(2016, 1, 1))
+    report_factory(duration=timedelta(hours=1), date=date(2015, 12, 4))
+    report_factory(duration=timedelta(hours=2), date=date(2015, 12, 31))
 
     url = reverse("month-statistic-list")
     result = auth_client.get(url, data={"ordering": "year,month"})

--- a/backend/timed/reports/tests/test_project_statistic.py
+++ b/backend/timed/reports/tests/test_project_statistic.py
@@ -4,10 +4,6 @@ import pytest
 from django.urls import reverse
 from rest_framework import status
 
-from timed.employment.factories import UserFactory
-from timed.projects.factories import CostCenterFactory, TaskAssigneeFactory, TaskFactory
-from timed.tracking.factories import ReportFactory
-
 
 @pytest.mark.parametrize(
     ("is_employed", "is_customer_assignee", "is_customer", "expected", "status_code"),
@@ -28,6 +24,8 @@ def test_project_statistic_list(
     status_code,
     django_assert_num_queries,
     setup_customer_and_employment_status,
+    report_factory,
+    task_factory,
 ):
     user = auth_client.user
     setup_customer_and_employment_status(
@@ -37,21 +35,21 @@ def test_project_statistic_list(
         is_employed=is_employed,
         is_external=False,
     )
-    report = ReportFactory.create(
+    report = report_factory(
         duration=timedelta(hours=1),
         task__project__total_remaining_effort=timedelta(hours=3),
         task__project__estimated_time=timedelta(hours=7),
     )
     project = report.task.project
-    ReportFactory.create(duration=timedelta(hours=2), task=report.task)
-    report2 = ReportFactory.create(
+    report_factory(duration=timedelta(hours=2), task=report.task)
+    report2 = report_factory(
         duration=timedelta(hours=4),
         task__project__total_remaining_effort=timedelta(hours=5),
         task__project__estimated_time=timedelta(hours=2),
     )
     project_2 = report2.task.project
-    task = TaskFactory(project=report.task.project)
-    ReportFactory.create(duration=timedelta(hours=2), task=task)
+    task = task_factory(project=report.task.project)
+    report_factory(duration=timedelta(hours=2), task=task)
 
     url = reverse("project-statistic-list")
     with django_assert_num_queries(expected):
@@ -123,6 +121,11 @@ def test_project_statistic_filtered(
     filter,  # noqa: A002
     expected_result,
     setup_customer_and_employment_status,
+    cost_center_factory,
+    report_factory,
+    task_assignee_factory,
+    task_factory,
+    user_factory,
 ):
     user = auth_client.user
     setup_customer_and_employment_status(
@@ -133,14 +136,16 @@ def test_project_statistic_filtered(
         is_external=False,
     )
 
-    cost_center = CostCenterFactory()
-    task_z = TaskFactory.create(name="Z", cost_center=cost_center)
-    task_test = TaskFactory.create(name="Test")
-    reviewer = TaskAssigneeFactory(user=UserFactory(), task=task_test, is_reviewer=True)
+    cost_center = cost_center_factory()
+    task_z = task_factory(name="Z", cost_center=cost_center)
+    task_test = task_factory(name="Test")
+    reviewer = task_assignee_factory(
+        user=user_factory(), task=task_test, is_reviewer=True
+    )
 
-    ReportFactory.create(duration=timedelta(hours=1), date="2022-08-05", task=task_test)
-    ReportFactory.create(duration=timedelta(hours=2), date="2022-08-30", task=task_test)
-    ReportFactory.create(duration=timedelta(hours=3), date="2022-09-01", task=task_z)
+    report_factory(duration=timedelta(hours=1), date="2022-08-05", task=task_test)
+    report_factory(duration=timedelta(hours=2), date="2022-08-30", task=task_test)
+    report_factory(duration=timedelta(hours=3), date="2022-09-01", task=task_z)
 
     filter_values = {
         "from_date": "2022-08-20",  # last two reports

--- a/backend/timed/reports/tests/test_task_statistic.py
+++ b/backend/timed/reports/tests/test_task_statistic.py
@@ -4,10 +4,6 @@ import pytest
 from django.urls import reverse
 from rest_framework import status
 
-from timed.employment.factories import UserFactory
-from timed.projects.factories import CostCenterFactory, TaskAssigneeFactory, TaskFactory
-from timed.tracking.factories import ReportFactory
-
 
 @pytest.mark.parametrize(
     ("is_employed", "is_customer_assignee", "is_customer", "expected", "status_code"),
@@ -28,6 +24,8 @@ def test_task_statistic_list(
     status_code,
     django_assert_num_queries,
     setup_customer_and_employment_status,
+    report_factory,
+    task_factory,
 ):
     user = auth_client.user
     setup_customer_and_employment_status(
@@ -37,19 +35,19 @@ def test_task_statistic_list(
         is_employed=is_employed,
         is_external=False,
     )
-    task_z = TaskFactory.create(
+    task_z = task_factory(
         name="Z",
         most_recent_remaining_effort=timedelta(hours=3),
         estimated_time=timedelta(hours=5),
     )
-    task_test = TaskFactory.create(
+    task_test = task_factory(
         name="Test",
         most_recent_remaining_effort=timedelta(hours=7),
         estimated_time=timedelta(hours=2),
     )
-    ReportFactory.create(duration=timedelta(hours=1), task=task_test)
-    ReportFactory.create(duration=timedelta(hours=2), task=task_test)
-    ReportFactory.create(duration=timedelta(hours=2), task=task_z)
+    report_factory(duration=timedelta(hours=1), task=task_test)
+    report_factory(duration=timedelta(hours=2), task=task_test)
+    report_factory(duration=timedelta(hours=2), task=task_z)
 
     url = reverse("task-statistic-list")
     with django_assert_num_queries(expected):
@@ -111,6 +109,11 @@ def test_task_statistic_filtered(
     filter,  # noqa: A002
     expected_result,
     setup_customer_and_employment_status,
+    cost_center_factory,
+    report_factory,
+    task_assignee_factory,
+    task_factory,
+    user_factory,
 ):
     user = auth_client.user
     setup_customer_and_employment_status(
@@ -121,14 +124,16 @@ def test_task_statistic_filtered(
         is_external=False,
     )
 
-    cost_center = CostCenterFactory()
-    task_z = TaskFactory.create(name="Z", cost_center=cost_center)
-    task_test = TaskFactory.create(name="Test")
-    reviewer = TaskAssigneeFactory(user=UserFactory(), task=task_test, is_reviewer=True)
+    cost_center = cost_center_factory()
+    task_z = task_factory(name="Z", cost_center=cost_center)
+    task_test = task_factory(name="Test")
+    reviewer = task_assignee_factory(
+        user=user_factory(), task=task_test, is_reviewer=True
+    )
 
-    ReportFactory.create(duration=timedelta(hours=1), date="2022-08-05", task=task_test)
-    ReportFactory.create(duration=timedelta(hours=2), date="2022-08-30", task=task_test)
-    ReportFactory.create(duration=timedelta(hours=4), date="2022-09-01", task=task_z)
+    report_factory(duration=timedelta(hours=1), date="2022-08-05", task=task_test)
+    report_factory(duration=timedelta(hours=2), date="2022-08-30", task=task_test)
+    report_factory(duration=timedelta(hours=4), date="2022-09-01", task=task_z)
 
     filter_values = {
         "from_date": "2022-08-20",  # last two reports
@@ -153,6 +158,11 @@ def test_task_statistic_filtered(
 def test_task_statistic_multiple_filters(
     auth_client,
     setup_customer_and_employment_status,
+    cost_center_factory,
+    report_factory,
+    task_assignee_factory,
+    task_factory,
+    user_factory,
 ):
     user = auth_client.user
     setup_customer_and_employment_status(
@@ -163,14 +173,16 @@ def test_task_statistic_multiple_filters(
         is_external=False,
     )
 
-    cost_center = CostCenterFactory()
-    task_z = TaskFactory.create(name="Z", cost_center=cost_center)
-    task_test = TaskFactory.create(name="Test")
-    reviewer = TaskAssigneeFactory(user=UserFactory(), task=task_test, is_reviewer=True)
+    cost_center = cost_center_factory()
+    task_z = task_factory(name="Z", cost_center=cost_center)
+    task_test = task_factory(name="Test")
+    reviewer = task_assignee_factory(
+        user=user_factory(), task=task_test, is_reviewer=True
+    )
 
-    ReportFactory.create(duration=timedelta(hours=1), date="2022-08-05", task=task_test)
-    ReportFactory.create(duration=timedelta(hours=2), date="2022-08-30", task=task_test)
-    ReportFactory.create(duration=timedelta(hours=4), date="2022-09-01", task=task_z)
+    report_factory(duration=timedelta(hours=1), date="2022-08-05", task=task_test)
+    report_factory(duration=timedelta(hours=2), date="2022-08-30", task=task_test)
+    report_factory(duration=timedelta(hours=4), date="2022-09-01", task=task_z)
 
     url = reverse("task-statistic-list")
     result = auth_client.get(

--- a/backend/timed/reports/tests/test_user_statistic.py
+++ b/backend/timed/reports/tests/test_user_statistic.py
@@ -4,8 +4,6 @@ import pytest
 from django.urls import reverse
 from rest_framework import status
 
-from timed.tracking.factories import ReportFactory
-
 
 @pytest.mark.parametrize(
     ("is_employed", "is_customer_assignee", "is_customer", "status_code"),
@@ -24,6 +22,7 @@ def test_user_statistic_list(
     is_customer,
     status_code,
     setup_customer_and_employment_status,
+    report_factory,
 ):
     user = auth_client.user
     setup_customer_and_employment_status(
@@ -33,9 +32,9 @@ def test_user_statistic_list(
         is_employed=is_employed,
         is_external=False,
     )
-    ReportFactory.create(duration=timedelta(hours=1), user=user)
-    ReportFactory.create(duration=timedelta(hours=2), user=user)
-    report = ReportFactory.create(duration=timedelta(hours=2))
+    report_factory(duration=timedelta(hours=1), user=user)
+    report_factory(duration=timedelta(hours=2), user=user)
+    report = report_factory(duration=timedelta(hours=2))
 
     url = reverse("user-statistic-list")
     result = auth_client.get(url, data={"ordering": "duration", "include": "user"})

--- a/backend/timed/reports/tests/test_work_report.py
+++ b/backend/timed/reports/tests/test_work_report.py
@@ -7,10 +7,7 @@ import pytest
 from django.urls import reverse
 from rest_framework import status
 
-from timed.employment.factories import EmploymentFactory
-from timed.projects.factories import CustomerFactory, ProjectFactory, TaskFactory
 from timed.reports.views import WorkReportViewSet
-from timed.tracking.factories import ReportFactory
 
 
 @pytest.mark.freeze_time("2017-09-01")
@@ -34,6 +31,10 @@ def test_work_report_single_project(
     status_code,
     django_assert_num_queries,
     setup_customer_and_employment_status,
+    customer_factory,
+    project_factory,
+    report_factory,
+    task_factory,
 ):
     user = auth_client.user
     setup_customer_and_employment_status(
@@ -44,11 +45,11 @@ def test_work_report_single_project(
         is_external=False,
     )
     # spaces should be replaced with underscore
-    customer = CustomerFactory.create(name="Customer Name")
+    customer = customer_factory(name="Customer Name")
     # slashes should be dropped from file name
-    project = ProjectFactory.create(customer=customer, name="Project/")
-    task = TaskFactory.create(project=project)
-    ReportFactory.create_batch(
+    project = project_factory(customer=customer, name="Project/")
+    task = task_factory(project=project)
+    report_factory.create_batch(
         5,
         user=user,
         verified_by=user,
@@ -56,7 +57,7 @@ def test_work_report_single_project(
         date=date(2017, 8, 17),
         not_billable=True,
     )
-    ReportFactory.create_batch(
+    report_factory.create_batch(
         5,
         user=user,
         verified_by=user,
@@ -100,19 +101,28 @@ def test_work_report_single_project(
     ],
 )
 def test_work_report_multiple_projects(
-    auth_client, is_employed, status_code, expected, django_assert_num_queries
+    auth_client,
+    is_employed,
+    status_code,
+    expected,
+    django_assert_num_queries,
+    customer_factory,
+    employment_factory,
+    project_factory,
+    report_factory,
+    task_factory,
 ):
     num_projects = 2
 
     user = auth_client.user
     if is_employed:
-        EmploymentFactory.create(user=user)
-    customer = CustomerFactory.create(name="Customer")
+        employment_factory(user=user)
+    customer = customer_factory(name="Customer")
     report_date = date(2017, 8, 17)
     for i in range(num_projects):
-        project = ProjectFactory.create(customer=customer, name=f"Project{i}")
-        task = TaskFactory.create(project=project)
-        ReportFactory.create_batch(10, user=user, task=task, date=report_date)
+        project = project_factory(customer=customer, name=f"Project{i}")
+        task = task_factory(project=project)
+        report_factory.create_batch(10, user=user, task=task, date=report_date)
 
     url = reverse("work-report-list")
     with django_assert_num_queries(expected):
@@ -147,14 +157,16 @@ def test_work_report_empty(auth_client):
         ("Customer$Name", "Project", "1708-20170818-CustomerName-Project.ods"),
     ],
 )
-def test_generate_work_report_name(customer_name, project_name, expected):
+def test_generate_work_report_name(
+    customer_name, project_name, expected, customer_factory, project_factory
+):
     test_date = date(2017, 8, 18)
     view = WorkReportViewSet()
 
     # spaces should be replaced with underscore
-    customer = CustomerFactory.create(name=customer_name)
+    customer = customer_factory(name=customer_name)
     # slashes should be dropped from file name
-    project = ProjectFactory.create(customer=customer, name=project_name)
+    project = project_factory(customer=customer, name=project_name)
 
     name = view._generate_workreport_name(test_date, project)  # noqa: SLF001
     assert name == expected
@@ -171,17 +183,25 @@ def test_generate_work_report_name(customer_name, project_name, expected):
     ],
 )
 def test_work_report_count(
-    internal_employee_client, settings, settings_count, given_count, expected_status
+    internal_employee_client,
+    settings,
+    settings_count,
+    given_count,
+    expected_status,
+    customer_factory,
+    project_factory,
+    report_factory,
+    task_factory,
 ):
     user = internal_employee_client.user
-    customer = CustomerFactory.create(name="Customer")
+    customer = customer_factory(name="Customer")
     report_date = date(2017, 8, 17)
 
     settings.WORK_REPORTS_EXPORT_MAX_COUNT = settings_count
 
-    project = ProjectFactory.create(customer=customer)
-    task = TaskFactory.create(project=project)
-    ReportFactory.create_batch(given_count, user=user, task=task, date=report_date)
+    project = project_factory(customer=customer)
+    task = task_factory(project=project)
+    report_factory.create_batch(given_count, user=user, task=task, date=report_date)
 
     url = reverse("work-report-list")
     res = internal_employee_client.get(

--- a/backend/timed/reports/tests/test_year_statistic.py
+++ b/backend/timed/reports/tests/test_year_statistic.py
@@ -4,9 +4,6 @@ import pytest
 from django.urls import reverse
 from rest_framework import status
 
-from timed.employment.factories import EmploymentFactory
-from timed.tracking.factories import ReportFactory
-
 
 @pytest.mark.parametrize(
     ("is_employed", "is_customer_assignee", "is_customer", "expected"),
@@ -25,6 +22,7 @@ def test_year_statistic_list(
     is_customer,
     expected,
     setup_customer_and_employment_status,
+    report_factory,
 ):
     user = auth_client.user
     setup_customer_and_employment_status(
@@ -35,9 +33,9 @@ def test_year_statistic_list(
         is_external=False,
     )
 
-    ReportFactory.create(duration=timedelta(hours=1), date=date(2017, 1, 1))
-    ReportFactory.create(duration=timedelta(hours=1), date=date(2015, 2, 28))
-    ReportFactory.create(duration=timedelta(hours=1), date=date(2015, 12, 31))
+    report_factory(duration=timedelta(hours=1), date=date(2017, 1, 1))
+    report_factory(duration=timedelta(hours=1), date=date(2015, 2, 28))
+    report_factory(duration=timedelta(hours=1), date=date(2015, 12, 31))
 
     url = reverse("year-statistic-list")
     result = auth_client.get(url, data={"ordering": "year"})
@@ -68,11 +66,13 @@ def test_year_statistic_list(
         (False, status.HTTP_403_FORBIDDEN),
     ],
 )
-def test_year_statistic_detail(auth_client, is_employed, expected):
+def test_year_statistic_detail(
+    auth_client, is_employed, expected, employment_factory, report_factory
+):
     if is_employed:
-        EmploymentFactory.create(user=auth_client.user)
-    ReportFactory.create(duration=timedelta(hours=1), date=date(2015, 2, 28))
-    ReportFactory.create(duration=timedelta(hours=1), date=date(2015, 12, 31))
+        employment_factory(user=auth_client.user)
+    report_factory(duration=timedelta(hours=1), date=date(2015, 2, 28))
+    report_factory(duration=timedelta(hours=1), date=date(2015, 12, 31))
 
     url = reverse("year-statistic-detail", args=[2015])
     result = auth_client.get(url, data={"ordering": "year"})

--- a/backend/timed/subscription/tests/test_order.py
+++ b/backend/timed/subscription/tests/test_order.py
@@ -5,8 +5,6 @@ from django.urls import reverse
 from rest_framework import status
 
 from timed.notifications.models import Notification
-from timed.projects.factories import CustomerAssigneeFactory, ProjectFactory
-from timed.subscription import factories
 
 
 @pytest.mark.parametrize(
@@ -18,13 +16,20 @@ from timed.subscription import factories
         (False, False, False),
     ],
 )
-def test_order_list(auth_client, is_customer, is_accountant, is_superuser):
+def test_order_list(
+    auth_client,
+    is_customer,
+    is_accountant,
+    is_superuser,
+    customer_assignee_factory,
+    order_factory,
+):
     """Test which user can see orders."""
-    order = factories.OrderFactory.create()
+    order = order_factory()
     user = auth_client.user
 
     if is_customer:
-        CustomerAssigneeFactory.create(
+        customer_assignee_factory(
             customer=order.project.customer, user=user, is_customer=True
         )
     elif is_accountant:
@@ -60,10 +65,17 @@ def test_order_list(auth_client, is_customer, is_accountant, is_superuser):
     ],
 )
 def test_order_delete(
-    auth_client, is_customer, is_accountant, is_superuser, confirmed, expected
+    auth_client,
+    is_customer,
+    is_accountant,
+    is_superuser,
+    confirmed,
+    expected,
+    customer_assignee_factory,
+    order_factory,
 ):
     """Test which user can delete orders, confirmed or not."""
-    order = factories.OrderFactory()
+    order = order_factory()
     if confirmed:
         order.acknowledged = True
         order.save()
@@ -71,7 +83,7 @@ def test_order_delete(
     user = auth_client.user
 
     if is_customer:
-        CustomerAssigneeFactory.create(
+        customer_assignee_factory(
             customer=order.project.customer, user=user, is_customer=True
         )
     elif is_accountant:
@@ -97,10 +109,16 @@ def test_order_delete(
     ],
 )
 def test_order_confirm(
-    auth_client, is_superuser, is_accountant, is_customer, status_code
+    auth_client,
+    is_superuser,
+    is_accountant,
+    is_customer,
+    status_code,
+    customer_assignee_factory,
+    order_factory,
 ):
     """Test which user may confirm orders."""
-    order = factories.OrderFactory.create()
+    order = order_factory()
     user = auth_client.user
 
     if is_superuser:
@@ -110,7 +128,7 @@ def test_order_confirm(
         user.is_accountant = True
         user.save()
     elif is_customer:
-        CustomerAssigneeFactory.create(
+        customer_assignee_factory(
             user=user, is_customer=True, customer=order.project.customer
         )
 
@@ -164,16 +182,18 @@ def test_order_create(
     mail_sent,
     project_estimate,
     expected,
+    customer_assignee_factory,
+    project_factory,
 ):
     """Test which user may create orders.
 
     Additionally test if for creation of acknowledged/confirmed orders.
     """
     user = auth_client.user
-    project = ProjectFactory.create(estimated_time=project_estimate)
+    project = project_factory(estimated_time=project_estimate)
 
     if is_customer:
-        CustomerAssigneeFactory.create(
+        customer_assignee_factory(
             user=user, is_customer=True, customer=project.customer
         )
     elif is_accountant:
@@ -227,13 +247,17 @@ def test_order_create(
     ],
 )
 def test_order_create_duration(
-    auth_client, mailoutbox, duration, expected, status_code
+    auth_client,
+    mailoutbox,
+    duration,
+    expected,
+    status_code,
+    customer_assignee_factory,
+    project_factory,
 ):
     user = auth_client.user
-    project = ProjectFactory.create(estimated_time=timedelta(hours=1))
-    CustomerAssigneeFactory.create(
-        user=user, is_customer=True, customer=project.customer
-    )
+    project = project_factory(estimated_time=timedelta(hours=1))
+    customer_assignee_factory(user=user, is_customer=True, customer=project.customer)
 
     data = {
         "data": {
@@ -277,17 +301,24 @@ def test_order_create_duration(
     ],
 )
 def test_order_update(
-    auth_client, is_customer, is_accountant, is_superuser, acknowledged, expected
+    auth_client,
+    is_customer,
+    is_accountant,
+    is_superuser,
+    acknowledged,
+    expected,
+    customer_assignee_factory,
+    order_factory,
 ):
     user = auth_client.user
-    order = factories.OrderFactory.create()
+    order = order_factory()
 
     if acknowledged:
         order.acknowledged = True
         order.save()
 
     if is_customer:
-        CustomerAssigneeFactory.create(
+        customer_assignee_factory(
             user=user, is_customer=True, customer=order.project.customer
         )
     elif is_accountant:

--- a/backend/timed/subscription/tests/test_package.py
+++ b/backend/timed/subscription/tests/test_package.py
@@ -1,12 +1,9 @@
 from django.urls import reverse
 from rest_framework.status import HTTP_200_OK
 
-from timed.projects.factories import BillingTypeFactory, CustomerFactory, ProjectFactory
-from timed.subscription.factories import PackageFactory
 
-
-def test_subscription_package_list(auth_client):
-    PackageFactory.create()
+def test_subscription_package_list(auth_client, package_factory):
+    package_factory()
 
     url = reverse("subscription-package-list")
 
@@ -17,11 +14,17 @@ def test_subscription_package_list(auth_client):
     assert len(json["data"]) == 1
 
 
-def test_subscription_package_filter_customer(auth_client):
-    customer = CustomerFactory.create()
-    billing_type = BillingTypeFactory.create()
-    package = PackageFactory.create(billing_type=billing_type)
-    ProjectFactory.create_batch(2, billing_type=billing_type, customer=customer)
+def test_subscription_package_filter_customer(
+    auth_client,
+    billing_type_factory,
+    customer_factory,
+    package_factory,
+    project_factory,
+):
+    customer = customer_factory()
+    billing_type = billing_type_factory()
+    package = package_factory(billing_type=billing_type)
+    project_factory.create_batch(2, billing_type=billing_type, customer=customer)
 
     url = reverse("subscription-package-list")
 

--- a/backend/timed/subscription/tests/test_subscription_project.py
+++ b/backend/timed/subscription/tests/test_subscription_project.py
@@ -4,49 +4,50 @@ import pytest
 from django.urls import reverse
 from rest_framework.status import HTTP_200_OK, HTTP_404_NOT_FOUND
 
-from timed.employment.factories import EmploymentFactory
-from timed.projects.factories import (
-    BillingTypeFactory,
-    CustomerAssigneeFactory,
-    CustomerFactory,
-    ProjectFactory,
-    TaskFactory,
-)
-from timed.subscription.factories import OrderFactory, PackageFactory
-from timed.tracking.factories import ReportFactory
-
 
 @pytest.mark.parametrize(("is_external", "expected"), [(True, 0), (False, 1)])
-def test_subscription_project_list(auth_client, is_external, expected):
-    employment = EmploymentFactory.create(user=auth_client.user, is_external=False)
+def test_subscription_project_list(
+    auth_client,
+    is_external,
+    expected,
+    billing_type_factory,
+    customer_factory,
+    employment_factory,
+    order_factory,
+    package_factory,
+    project_factory,
+    report_factory,
+    task_factory,
+):
+    employment = employment_factory(user=auth_client.user, is_external=False)
     if is_external:
         employment.is_external = True
         employment.save()
-    customer = CustomerFactory.create()
-    billing_type = BillingTypeFactory()
-    project = ProjectFactory.create(
+    customer = customer_factory()
+    billing_type = billing_type_factory()
+    project = project_factory(
         billing_type=billing_type, customer=customer, customer_visible=True
     )
-    PackageFactory.create_batch(2, billing_type=billing_type)
+    package_factory.create_batch(2, billing_type=billing_type)
     # create spent hours
-    task = TaskFactory.create(project=project)
-    TaskFactory.create(project=project)
-    ReportFactory.create(task=task, duration=timedelta(hours=2))
-    ReportFactory.create(task=task, duration=timedelta(hours=3))
+    task = task_factory(project=project)
+    task_factory(project=project)
+    report_factory(task=task, duration=timedelta(hours=2))
+    report_factory(task=task, duration=timedelta(hours=3))
     # not billable reports should not be included in spent hours
-    ReportFactory.create(not_billable=True, task=task, duration=timedelta(hours=4))
+    report_factory(not_billable=True, task=task, duration=timedelta(hours=4))
     # project of same customer but without customer_visible set
     # should not appear
-    ProjectFactory.create(customer=customer)
+    project_factory(customer=customer)
 
     # create purchased time
-    OrderFactory.create(project=project, acknowledged=True, duration=timedelta(hours=2))
-    OrderFactory.create(project=project, acknowledged=True, duration=timedelta(hours=4))
+    order_factory(project=project, acknowledged=True, duration=timedelta(hours=2))
+    order_factory(project=project, acknowledged=True, duration=timedelta(hours=4))
 
     # report on different project should not be included in spent time
-    ReportFactory.create(duration=timedelta(hours=2))
+    report_factory(duration=timedelta(hours=2))
     # not acknowledged order should not be included in purchased time
-    OrderFactory.create(project=project, duration=timedelta(hours=2))
+    order_factory(project=project, duration=timedelta(hours=2))
 
     url = reverse("subscription-project-list")
 
@@ -73,21 +74,31 @@ def test_subscription_project_list(auth_client, is_external, expected):
     ],
 )
 def test_subscription_project_detail(
-    auth_client, is_customer, project_of_customer, has_employment, is_external, expected
+    auth_client,
+    is_customer,
+    project_of_customer,
+    has_employment,
+    is_external,
+    expected,
+    billing_type_factory,
+    customer_assignee_factory,
+    employment_factory,
+    package_factory,
+    project_factory,
 ):
     user = auth_client.user
-    billing_type = BillingTypeFactory()
-    project = ProjectFactory.create(billing_type=billing_type, customer_visible=True)
-    PackageFactory.create_batch(2, billing_type=billing_type)
+    billing_type = billing_type_factory()
+    project = project_factory(billing_type=billing_type, customer_visible=True)
+    package_factory.create_batch(2, billing_type=billing_type)
 
     if has_employment:
-        employment = EmploymentFactory.create(user=user, is_external=False)
+        employment = employment_factory(user=user, is_external=False)
         if is_external:
             employment.is_external = True
             employment.save()
 
     if is_customer:
-        customer_assignee = CustomerAssigneeFactory(user=user, is_customer=True)
+        customer_assignee = customer_assignee_factory(user=user, is_customer=True)
         if project_of_customer:
             customer_assignee.customer = project.customer
             customer_assignee.save()
@@ -101,13 +112,15 @@ def test_subscription_project_detail(
         assert json["data"]["id"] == str(project.id)
 
 
-def test_subscription_project_list_user_is_customer(auth_client):
-    customer = CustomerFactory.create()
-    project = ProjectFactory.create(customer=customer, customer_visible=True)
-    ProjectFactory.create_batch(4, customer_visible=True)
+def test_subscription_project_list_user_is_customer(
+    auth_client, customer_assignee_factory, customer_factory, project_factory
+):
+    customer = customer_factory()
+    project = project_factory(customer=customer, customer_visible=True)
+    project_factory.create_batch(4, customer_visible=True)
 
     user = auth_client.user
-    CustomerAssigneeFactory.create(user=user, customer=customer, is_customer=True)
+    customer_assignee_factory(user=user, customer=customer, is_customer=True)
 
     url = reverse("subscription-project-list")
 

--- a/backend/timed/tests/test_authentication.py
+++ b/backend/timed/tests/test_authentication.py
@@ -10,8 +10,6 @@ from rest_framework import exceptions, status
 from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.reverse import reverse
 
-from timed.employment.factories import UserFactory
-
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("is_id_token", [True, False])
@@ -91,9 +89,9 @@ def test_authentication_new_user(
 
 
 @pytest.mark.django_db
-def test_authentication_update_user_data(rf, requests_mock, settings):
+def test_authentication_update_user_data(rf, requests_mock, settings, user_factory):
     user_model = get_user_model()
-    user = UserFactory.create()
+    user = user_factory()
 
     userinfo = {
         "sub": user.username,

--- a/backend/timed/tracking/tests/test_absence.py
+++ b/backend/timed/tracking/tests/test_absence.py
@@ -7,14 +7,6 @@ import pytest
 from django.urls import reverse
 from rest_framework import status
 
-from timed.employment.factories import (
-    AbsenceTypeFactory,
-    EmploymentFactory,
-    PublicHolidayFactory,
-    UserFactory,
-)
-from timed.tracking.factories import AbsenceFactory, ReportFactory
-
 if TYPE_CHECKING:
     from timed.employment.models import AbsenceType
     from timed.tracking.models import Absence
@@ -24,21 +16,27 @@ if TYPE_CHECKING:
     "is_external",
     [True, False],
 )
-def test_absence_list_authenticated(auth_client, is_external):
-    absence = AbsenceFactory.create(user=auth_client.user)
+def test_absence_list_authenticated(
+    auth_client,
+    is_external,
+    absence_factory,
+    employment_factory,
+    public_holiday_factory,
+):
+    absence = absence_factory(user=auth_client.user)
 
     # overlapping absence with public holidays need to be hidden
-    overlap_absence = AbsenceFactory.create(
+    overlap_absence = absence_factory(
         user=auth_client.user, date=datetime.date(2018, 1, 1)
     )
-    employment = EmploymentFactory.create(
+    employment = employment_factory(
         user=overlap_absence.user, start_date=datetime.date(2017, 12, 31)
     )
     if is_external:
         employment.is_external = True
         employment.save()
 
-    PublicHolidayFactory.create(date=overlap_absence.date, location=employment.location)
+    public_holiday_factory(date=overlap_absence.date, location=employment.location)
     url = reverse("absence-list")
 
     response = auth_client.get(url)
@@ -51,8 +49,8 @@ def test_absence_list_authenticated(auth_client, is_external):
         assert json["data"][0]["id"] == str(absence.id)
 
 
-def test_absence_list_superuser(superadmin_client):
-    AbsenceFactory.create_batch(2)
+def test_absence_list_superuser(superadmin_client, absence_factory):
+    absence_factory.create_batch(2)
 
     url = reverse("absence-list")
     response = superadmin_client.get(url)
@@ -62,12 +60,14 @@ def test_absence_list_superuser(superadmin_client):
     assert len(json["data"]) == 2
 
 
-def test_absence_list_supervisor(internal_employee_client):
-    user = UserFactory.create()
+def test_absence_list_supervisor(
+    internal_employee_client, absence_factory, user_factory
+):
+    user = user_factory()
     internal_employee_client.user.supervisees.add(user)
 
-    AbsenceFactory.create(user=internal_employee_client.user)
-    AbsenceFactory.create(user=user)
+    absence_factory(user=internal_employee_client.user)
+    absence_factory(user=user)
 
     url = reverse("absence-list")
     response = internal_employee_client.get(url)
@@ -76,13 +76,15 @@ def test_absence_list_supervisor(internal_employee_client):
     assert len(json["data"]) == 2
 
 
-def test_absence_list_supervisee(internal_employee_client):
-    AbsenceFactory.create(user=internal_employee_client.user)
+def test_absence_list_supervisee(
+    internal_employee_client, absence_factory, user_factory
+):
+    absence_factory(user=internal_employee_client.user)
 
-    supervisors = UserFactory.create_batch(2)
+    supervisors = user_factory.create_batch(2)
 
     supervisors[0].supervisees.add(internal_employee_client.user)
-    AbsenceFactory.create(user=supervisors[0])
+    absence_factory(user=supervisors[0])
 
     url = reverse("absence-list")
 
@@ -93,7 +95,7 @@ def test_absence_list_supervisee(internal_employee_client):
 
     # absences of multiple supervisors shouldn't affect supervisee
     supervisors[1].supervisees.add(internal_employee_client.user)
-    AbsenceFactory.create(user=supervisors[1])
+    absence_factory(user=supervisors[1])
 
     response = internal_employee_client.get(url)
     assert response.status_code == status.HTTP_200_OK
@@ -101,8 +103,8 @@ def test_absence_list_supervisee(internal_employee_client):
     assert len(json["data"]) == 1
 
 
-def test_absence_detail(internal_employee_client):
-    absence = AbsenceFactory.create(user=internal_employee_client.user)
+def test_absence_detail(internal_employee_client, absence_factory):
+    absence = absence_factory(user=internal_employee_client.user)
 
     url = reverse("absence-detail", args=[absence.id])
 
@@ -117,13 +119,15 @@ def test_absence_detail(internal_employee_client):
     ("is_external", "expected"),
     [(False, status.HTTP_201_CREATED), (True, status.HTTP_403_FORBIDDEN)],
 )
-def test_absence_create(auth_client, is_external, expected):
+def test_absence_create(
+    auth_client, is_external, expected, absence_type_factory, employment_factory
+):
     user = auth_client.user
     date = datetime.date(2017, 5, 4)
-    employment = EmploymentFactory.create(
+    employment = employment_factory(
         user=user, start_date=date, worktime_per_day=datetime.timedelta(hours=8)
     )
-    absence_type = AbsenceTypeFactory.create()
+    absence_type = absence_type_factory()
 
     if is_external:
         employment.is_external = True
@@ -155,13 +159,11 @@ def test_absence_create(auth_client, is_external, expected):
         )
 
 
-def test_absence_update_owner(auth_client):
+def test_absence_update_owner(auth_client, absence_factory, employment_factory):
     user = auth_client.user
     date = datetime.date(2017, 5, 3)
-    absence = AbsenceFactory.create(
-        user=auth_client.user, date=datetime.date(2016, 5, 3)
-    )
-    EmploymentFactory.create(
+    absence = absence_factory(user=auth_client.user, date=datetime.date(2016, 5, 3))
+    employment_factory(
         user=user, start_date=date, worktime_per_day=datetime.timedelta(hours=8)
     )
 
@@ -182,12 +184,14 @@ def test_absence_update_owner(auth_client):
     assert json["data"]["attributes"]["date"] == "2017-05-03"
 
 
-def test_absence_update_superadmin_date(superadmin_client):
+def test_absence_update_superadmin_date(
+    superadmin_client, absence_factory, employment_factory, user_factory
+):
     """Test that superadmin may not change date of absence."""
-    user = UserFactory.create()
+    user = user_factory()
     date = datetime.date(2017, 5, 3)
-    absence = AbsenceFactory.create(user=user, date=datetime.date(2016, 5, 3))
-    EmploymentFactory.create(
+    absence = absence_factory(user=user, date=datetime.date(2016, 5, 3))
+    employment_factory(
         user=user, start_date=date, worktime_per_day=datetime.timedelta(hours=8)
     )
 
@@ -205,13 +209,19 @@ def test_absence_update_superadmin_date(superadmin_client):
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_absence_update_superadmin_type(superadmin_client):
+def test_absence_update_superadmin_type(
+    superadmin_client,
+    absence_factory,
+    absence_type_factory,
+    employment_factory,
+    user_factory,
+):
     """Test that superadmin may not change type of absence."""
-    user = UserFactory.create()
+    user = user_factory()
     date = datetime.date(2017, 5, 3)
-    absence_type = AbsenceTypeFactory.create()
-    absence = AbsenceFactory.create(user=user, date=datetime.date(2016, 5, 3))
-    EmploymentFactory.create(
+    absence_type = absence_type_factory()
+    absence = absence_factory(user=user, date=datetime.date(2016, 5, 3))
+    employment_factory(
         user=user, start_date=date, worktime_per_day=datetime.timedelta(hours=8)
     )
 
@@ -234,8 +244,8 @@ def test_absence_update_superadmin_type(superadmin_client):
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_absence_delete_owner(internal_employee_client):
-    absence = AbsenceFactory.create(user=internal_employee_client.user)
+def test_absence_delete_owner(internal_employee_client, absence_factory):
+    absence = absence_factory(user=internal_employee_client.user)
 
     url = reverse("absence-detail", args=[absence.id])
 
@@ -243,10 +253,10 @@ def test_absence_delete_owner(internal_employee_client):
     assert response.status_code == status.HTTP_204_NO_CONTENT
 
 
-def test_absence_delete_superuser(superadmin_client):
+def test_absence_delete_superuser(superadmin_client, absence_factory, user_factory):
     """Test that superuser may not delete absences of other users."""
-    user = UserFactory.create()
-    absence = AbsenceFactory.create(user=user)
+    user = user_factory()
+    absence = absence_factory(user=user)
 
     url = reverse("absence-detail", args=[absence.id])
 
@@ -254,16 +264,18 @@ def test_absence_delete_superuser(superadmin_client):
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_absence_fill_worktime(auth_client):
+def test_absence_fill_worktime(
+    auth_client, absence_type_factory, employment_factory, report_factory
+):
     """Should create an absence which fills the worktime."""
     date = datetime.date(2017, 5, 10)
     user = auth_client.user
-    EmploymentFactory.create(
+    employment_factory(
         user=user, start_date=date, worktime_per_day=datetime.timedelta(hours=8)
     )
-    absence_type = AbsenceTypeFactory.create(fill_worktime=True)
+    absence_type = absence_type_factory(fill_worktime=True)
 
-    ReportFactory.create(user=user, date=date, duration=datetime.timedelta(hours=5))
+    report_factory(user=user, date=date, duration=datetime.timedelta(hours=5))
 
     data = {
         "data": {
@@ -287,7 +299,9 @@ def test_absence_fill_worktime(auth_client):
     assert json["data"]["attributes"]["duration"] == "03:00:00"
 
 
-def test_absence_fill_worktime_reported_time_to_long(auth_client):
+def test_absence_fill_worktime_reported_time_to_long(
+    auth_client, absence_type_factory, employment_factory, report_factory
+):
     """
     Verify absence fill worktime is zero when reported time is too long.
 
@@ -295,12 +309,12 @@ def test_absence_fill_worktime_reported_time_to_long(auth_client):
     """
     date = datetime.date(2017, 5, 10)
     user = auth_client.user
-    EmploymentFactory.create(
+    employment_factory(
         user=user, start_date=date, worktime_per_day=datetime.timedelta(hours=8)
     )
-    absence_type = AbsenceTypeFactory.create(fill_worktime=True)
+    absence_type = absence_type_factory(fill_worktime=True)
 
-    ReportFactory.create(
+    report_factory(
         user=user, date=date, duration=datetime.timedelta(hours=8, minutes=30)
     )
 
@@ -326,12 +340,12 @@ def test_absence_fill_worktime_reported_time_to_long(auth_client):
     assert json["data"]["attributes"]["duration"] == "00:00:00"
 
 
-def test_absence_weekend(auth_client):
+def test_absence_weekend(auth_client, absence_type_factory, employment_factory):
     """Should not be able to create an absence on a weekend."""
     date = datetime.date(2017, 5, 14)
     user = auth_client.user
-    absence_type = AbsenceTypeFactory.create()
-    EmploymentFactory.create(
+    absence_type = absence_type_factory()
+    employment_factory(
         user=user, start_date=date, worktime_per_day=datetime.timedelta(hours=8)
     )
 
@@ -354,15 +368,17 @@ def test_absence_weekend(auth_client):
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_absence_public_holiday(auth_client):
+def test_absence_public_holiday(
+    auth_client, absence_type_factory, employment_factory, public_holiday_factory
+):
     """Should not be able to create an absence on a public holiday."""
     date = datetime.date(2017, 5, 16)
     user = auth_client.user
-    absence_type = AbsenceTypeFactory.create()
-    employment = EmploymentFactory.create(
+    absence_type = absence_type_factory()
+    employment = employment_factory(
         user=user, start_date=date, worktime_per_day=datetime.timedelta(hours=8)
     )
-    PublicHolidayFactory.create(location=employment.location, date=date)
+    public_holiday_factory(location=employment.location, date=date)
 
     data = {
         "data": {
@@ -383,9 +399,9 @@ def test_absence_public_holiday(auth_client):
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_absence_create_unemployed(auth_client):
+def test_absence_create_unemployed(auth_client, absence_type_factory):
     """Test creation of absence fails on unemployed day."""
-    absence_type = AbsenceTypeFactory.create()
+    absence_type = absence_type_factory()
 
     data = {
         "data": {
@@ -406,9 +422,9 @@ def test_absence_create_unemployed(auth_client):
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_absence_detail_unemployed(internal_employee_client):
+def test_absence_detail_unemployed(internal_employee_client, absence_factory):
     """Test creation of absence fails on unemployed day."""
-    absence = AbsenceFactory.create(user=internal_employee_client.user)
+    absence = absence_factory(user=internal_employee_client.user)
 
     url = reverse("absence-detail", args=[absence.id])
 

--- a/backend/timed/tracking/tests/test_activity.py
+++ b/backend/timed/tracking/tests/test_activity.py
@@ -4,12 +4,9 @@ import pytest
 from django.urls import reverse
 from rest_framework import status
 
-from timed.employment.factories import EmploymentFactory
-from timed.tracking.factories import ActivityFactory
 
-
-def test_activity_list(internal_employee_client):
-    activity = ActivityFactory.create(user=internal_employee_client.user)
+def test_activity_list(internal_employee_client, activity_factory):
+    activity = activity_factory(user=internal_employee_client.user)
     url = reverse("activity-list")
 
     response = internal_employee_client.get(url)
@@ -20,8 +17,8 @@ def test_activity_list(internal_employee_client):
     assert json["data"][0]["id"] == str(activity.id)
 
 
-def test_activity_detail(internal_employee_client):
-    activity = ActivityFactory.create(user=internal_employee_client.user)
+def test_activity_detail(internal_employee_client, activity_factory):
+    activity = activity_factory(user=internal_employee_client.user)
 
     url = reverse("activity-detail", args=[activity.id])
 
@@ -43,10 +40,12 @@ def test_activity_detail(internal_employee_client):
         (False, True, False, status.HTTP_201_CREATED),
     ],
 )
-def test_activity_create(auth_client, is_external, task_assignee, expected):
+def test_activity_create(
+    auth_client, is_external, task_assignee, expected, employment_factory
+):
     """Should create a new activity and automatically set the user."""
     user = auth_client.user
-    employment = EmploymentFactory(user=user)
+    employment = employment_factory(user=user)
 
     if is_external:
         employment.is_external = True
@@ -79,9 +78,11 @@ def test_activity_create(auth_client, is_external, task_assignee, expected):
         assert int(json["data"]["relationships"]["user"]["data"]["id"]) == int(user.id)
 
 
-def test_activity_create_no_task_external_employee(auth_client, task_assignee):
+def test_activity_create_no_task_external_employee(
+    auth_client, task_assignee, employment_factory
+):
     user = auth_client.user
-    EmploymentFactory(user=user)
+    employment_factory(user=user)
     task_assignee.user = user
     task_assignee.save()
 
@@ -120,12 +121,19 @@ def test_activity_create_no_task_external_employee(auth_client, task_assignee):
         (False, True, False, status.HTTP_200_OK),
     ],
 )
-def test_activity_update(auth_client, is_external, task_assignee, expected):
+def test_activity_update(
+    auth_client,
+    is_external,
+    task_assignee,
+    expected,
+    activity_factory,
+    employment_factory,
+):
     user = auth_client.user
-    activity = ActivityFactory.create(user=user, task=task_assignee.task)
+    activity = activity_factory(user=user, task=task_assignee.task)
     task_assignee.user = user
     task_assignee.save()
-    employment = EmploymentFactory(user=user)
+    employment = employment_factory(user=user)
 
     if is_external:
         employment.is_external = True
@@ -166,13 +174,20 @@ def test_activity_update(auth_client, is_external, task_assignee, expected):
         (False, True, False, status.HTTP_204_NO_CONTENT),
     ],
 )
-def test_activity_delete(auth_client, is_external, task_assignee, expected):
+def test_activity_delete(
+    auth_client,
+    is_external,
+    task_assignee,
+    expected,
+    activity_factory,
+    employment_factory,
+):
     user = auth_client.user
     task_assignee.user = user
     task_assignee.save()
-    activity = ActivityFactory.create(user=user, task=task_assignee.task)
+    activity = activity_factory(user=user, task=task_assignee.task)
 
-    employment = EmploymentFactory(user=user)
+    employment = employment_factory(user=user)
 
     if is_external:
         employment.is_external = True
@@ -184,10 +199,10 @@ def test_activity_delete(auth_client, is_external, task_assignee, expected):
     assert response.status_code == expected
 
 
-def test_activity_list_filter_active(internal_employee_client):
+def test_activity_list_filter_active(internal_employee_client, activity_factory):
     user = internal_employee_client.user
-    activity1 = ActivityFactory.create(user=user)
-    activity2 = ActivityFactory.create(user=user, to_time=None, task=activity1.task)
+    activity1 = activity_factory(user=user)
+    activity2 = activity_factory(user=user, to_time=None, task=activity1.task)
 
     url = reverse("activity-list")
 
@@ -198,11 +213,11 @@ def test_activity_list_filter_active(internal_employee_client):
     assert json["data"][0]["id"] == str(activity2.id)
 
 
-def test_activity_list_filter_day(internal_employee_client):
+def test_activity_list_filter_day(internal_employee_client, activity_factory):
     user = internal_employee_client.user
     day = date(2016, 2, 2)
-    ActivityFactory.create(date=day - timedelta(days=1), user=user)
-    activity = ActivityFactory.create(date=day, user=user)
+    activity_factory(date=day - timedelta(days=1), user=user)
+    activity = activity_factory(date=day, user=user)
 
     url = reverse("activity-list")
     response = internal_employee_client.get(url, data={"day": day.strftime("%Y-%m-%d")})
@@ -236,9 +251,9 @@ def test_activity_create_no_task(internal_employee_client):
     assert json["data"]["relationships"]["task"]["data"] is None
 
 
-def test_activity_active_unique(internal_employee_client):
+def test_activity_active_unique(internal_employee_client, activity_factory):
     """Should not be able to have two active blocks."""
-    ActivityFactory.create(user=internal_employee_client.user, to_time=None)
+    activity_factory(user=internal_employee_client.user, to_time=None)
 
     data = {
         "data": {
@@ -261,9 +276,9 @@ def test_activity_active_unique(internal_employee_client):
     assert json["errors"][0]["detail"] == ("A user can only have one active activity")
 
 
-def test_activity_to_before_from(internal_employee_client):
+def test_activity_to_before_from(internal_employee_client, activity_factory):
     """Test that to is not before from."""
-    activity = ActivityFactory.create(
+    activity = activity_factory(
         user=internal_employee_client.user, from_time=time(7, 30), to_time=None
     )
 
@@ -286,11 +301,9 @@ def test_activity_to_before_from(internal_employee_client):
     )
 
 
-def test_activity_not_editable(internal_employee_client):
+def test_activity_not_editable(internal_employee_client, activity_factory):
     """Test that transferred activities are read only."""
-    activity = ActivityFactory.create(
-        user=internal_employee_client.user, transferred=True
-    )
+    activity = activity_factory(user=internal_employee_client.user, transferred=True)
 
     data = {
         "data": {
@@ -305,11 +318,9 @@ def test_activity_not_editable(internal_employee_client):
     assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
-def test_activity_retrievable_not_editable(internal_employee_client):
+def test_activity_retrievable_not_editable(internal_employee_client, activity_factory):
     """Test that transferred activities are still retrievable."""
-    activity = ActivityFactory.create(
-        user=internal_employee_client.user, transferred=True
-    )
+    activity = activity_factory(user=internal_employee_client.user, transferred=True)
 
     url = reverse("activity-detail", args=[activity.id])
 
@@ -317,8 +328,8 @@ def test_activity_retrievable_not_editable(internal_employee_client):
     assert response.status_code == status.HTTP_200_OK
 
 
-def test_activity_active_update(internal_employee_client):
-    activity = ActivityFactory.create(user=internal_employee_client.user, to_time=None)
+def test_activity_active_update(internal_employee_client, activity_factory):
+    activity = activity_factory(user=internal_employee_client.user, to_time=None)
 
     data = {
         "data": {
@@ -357,10 +368,10 @@ def test_activity_set_to_time_none(internal_employee_client, activity_factory):
     assert res.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_activity_transfer_ends_it(internal_employee_client):
+def test_activity_transfer_ends_it(internal_employee_client, activity_factory):
     """Test that transferring activities ends them."""
 
-    activity = ActivityFactory.create(
+    activity = activity_factory(
         user=internal_employee_client.user,
         transferred=False,
         to_time=None,

--- a/backend/timed/tracking/tests/test_attendance.py
+++ b/backend/timed/tracking/tests/test_attendance.py
@@ -4,12 +4,10 @@ import pytest
 from django.urls import reverse
 from rest_framework import status
 
-from timed.tracking.factories import AttendanceFactory
 
-
-def test_attendance_list(internal_employee_client):
-    AttendanceFactory.create()
-    attendance = AttendanceFactory.create(user=internal_employee_client.user)
+def test_attendance_list(internal_employee_client, attendance_factory):
+    attendance_factory()
+    attendance = attendance_factory(user=internal_employee_client.user)
 
     url = reverse("attendance-list")
     response = internal_employee_client.get(url)
@@ -20,8 +18,8 @@ def test_attendance_list(internal_employee_client):
     assert json["data"][0]["id"] == str(attendance.id)
 
 
-def test_attendance_detail(internal_employee_client):
-    attendance = AttendanceFactory.create(user=internal_employee_client.user)
+def test_attendance_detail(internal_employee_client, attendance_factory):
+    attendance = attendance_factory(user=internal_employee_client.user)
 
     url = reverse("attendance-detail", args=[attendance.id])
     response = internal_employee_client.get(url)
@@ -71,9 +69,9 @@ def test_attendance_create(
         assert json["data"]["relationships"]["user"]["data"]["id"] == str(user.id)
 
 
-def test_attendance_update(internal_employee_client):
+def test_attendance_update(internal_employee_client, attendance_factory):
     user = internal_employee_client.user
-    attendance = AttendanceFactory.create(
+    attendance = attendance_factory(
         user=user, from_time=time(10, 0, 0), to_time=time(12, 0, 0)
     )
 
@@ -97,8 +95,8 @@ def test_attendance_update(internal_employee_client):
     )
 
 
-def test_attendance_delete(internal_employee_client):
-    attendance = AttendanceFactory.create(user=internal_employee_client.user)
+def test_attendance_delete(internal_employee_client, attendance_factory):
+    attendance = attendance_factory(user=internal_employee_client.user)
 
     url = reverse("attendance-detail", args=[attendance.id])
 

--- a/backend/timed/tracking/tests/test_report.py
+++ b/backend/timed/tracking/tests/test_report.py
@@ -11,14 +11,6 @@ from django.urls import reverse
 from django.utils.duration import duration_string
 from rest_framework import status
 
-from timed.employment.factories import EmploymentFactory, UserFactory
-from timed.projects.factories import (
-    CustomerAssigneeFactory,
-    ProjectAssigneeFactory,
-    TaskAssigneeFactory,
-    TaskFactory,
-)
-
 if TYPE_CHECKING:
     from timed.employment.models import User
     from timed.projects.models import Customer, Project, Task
@@ -30,8 +22,8 @@ def test_report_list(
     report_factory,
 ):
     user = internal_employee_client.user
-    report_factory.create(user=user)
-    report = report_factory.create(user=user, duration=timedelta(hours=1))
+    report_factory(user=user)
+    report = report_factory(user=user, duration=timedelta(hours=1))
     url = reverse("report-list")
 
     response = internal_employee_client.get(
@@ -58,7 +50,7 @@ def test_report_intersection_full(
     internal_employee_client,
     report_factory,
 ):
-    report = report_factory.create()
+    report = report_factory()
 
     url = reverse("report-intersection")
     response = internal_employee_client.get(
@@ -118,8 +110,8 @@ def test_report_intersection_partial(
     snapshot,
 ):
     user = internal_employee_client.user
-    report = report_factory.create(review=True, not_billable=True, comment="test")
-    report_factory.create(verified_by=user, comment="test")
+    report = report_factory(review=True, not_billable=True, comment="test")
+    report_factory(verified_by=user, comment="test")
     # Billed is not set on create because the factory doesnt seem to work with that
     report.billed = True
     report.save()
@@ -142,9 +134,9 @@ def test_report_intersection_accountant_editable(
     user.save()
 
     other_user = user_factory()
-    report_factory.create(review=True, not_billable=True, user=other_user)
+    report_factory(review=True, not_billable=True, user=other_user)
 
-    report1 = report_factory.create(review=True, not_billable=True, user=other_user)
+    report1 = report_factory(review=True, not_billable=True, user=other_user)
     report1.billed = True
     report1.save()
 
@@ -187,9 +179,9 @@ def test_report_intersection_accountant_not_editable(
     user.save()
 
     other_user = user_factory()
-    report_factory.create(review=True, not_billable=True, user=other_user)
+    report_factory(review=True, not_billable=True, user=other_user)
 
-    report = report_factory.create(review=True, not_billable=True, user=other_user)
+    report = report_factory(review=True, not_billable=True, user=other_user)
     report.billed = True
     report.save()
 
@@ -226,9 +218,9 @@ def test_report_list_filter_id(
     internal_employee_client,
     report_factory,
 ):
-    report_1 = report_factory.create(date="2017-01-01")
-    report_2 = report_factory.create(date="2017-02-01")
-    report_factory.create()
+    report_1 = report_factory(date="2017-01-01")
+    report_2 = report_factory(date="2017-02-01")
+    report_factory()
 
     url = reverse("report-list")
 
@@ -247,7 +239,7 @@ def test_report_list_filter_id_empty(
     report_factory,
 ):
     """Test that empty id filter is ignored."""
-    report_factory.create()
+    report_factory()
 
     url = reverse("report-list")
 
@@ -260,20 +252,22 @@ def test_report_list_filter_id_empty(
 def test_report_list_filter_reviewer(
     internal_employee_client,
     report_factory,
+    project_assignee_factory,
+    task_assignee_factory,
+    task_factory,
+    user_factory,
 ):
     user = internal_employee_client.user
-    report = report_factory.create(user=user)
-    ProjectAssigneeFactory.create(
-        user=user, project=report.task.project, is_reviewer=True
-    )
+    report = report_factory(user=user)
+    project_assignee_factory(user=user, project=report.task.project, is_reviewer=True)
 
     # add new task to the project
-    task2 = TaskFactory.create(project=report.task.project)
-    report_factory.create(user=user, task=task2)
+    task2 = task_factory(project=report.task.project)
+    report_factory(user=user, task=task2)
 
     # add task assignee with reviewer role to the new task
-    user2 = UserFactory.create()
-    TaskAssigneeFactory.create(user=user2, task=task2, is_reviewer=True)
+    user2 = user_factory()
+    task_assignee_factory(user=user2, task=task2, is_reviewer=True)
 
     url = reverse("report-list")
 
@@ -289,8 +283,8 @@ def test_report_list_filter_verifier(
     report_factory,
 ):
     user = internal_employee_client.user
-    report = report_factory.create(verified_by=user)
-    report_factory.create()
+    report = report_factory(verified_by=user)
+    report_factory()
 
     url = reverse("report-list")
 
@@ -306,8 +300,8 @@ def test_report_list_filter_editable_owner(
     report_factory,
 ):
     user = internal_employee_client.user
-    report = report_factory.create(user=user)
-    report_factory.create()
+    report = report_factory(user=user)
+    report_factory()
 
     url = reverse("report-list")
 
@@ -323,8 +317,8 @@ def test_report_list_filter_not_editable_owner(
     report_factory,
 ):
     user = internal_employee_client.user
-    report_factory.create(user=user)
-    report = report_factory.create()
+    report_factory(user=user)
+    report = report_factory()
 
     url = reverse("report-list")
 
@@ -336,29 +330,27 @@ def test_report_list_filter_not_editable_owner(
 
 
 def test_report_list_filter_editable_reviewer(
-    internal_employee_client, report_factory, user_factory
+    internal_employee_client, report_factory, user_factory, project_assignee_factory
 ):
     user = internal_employee_client.user
     # not editable report
-    report_factory.create()
+    report_factory()
 
     # editable reports
     # 1st report of current user
-    report_factory.create(user=user)
+    report_factory(user=user)
     # 2nd case: report of a project which has several
     # reviewers and report is created by current user
-    report = report_factory.create(user=user)
-    other_user = user_factory.create()
-    ProjectAssigneeFactory.create(
-        user=user, project=report.task.project, is_reviewer=True
-    )
-    ProjectAssigneeFactory.create(
+    report = report_factory(user=user)
+    other_user = user_factory()
+    project_assignee_factory(user=user, project=report.task.project, is_reviewer=True)
+    project_assignee_factory(
         user=other_user, project=report.task.project, is_reviewer=True
     )
     # 3rd case: report by other user and current user
     # is the reviewer
-    reviewer_report = report_factory.create()
-    ProjectAssigneeFactory.create(
+    reviewer_report = report_factory()
+    project_assignee_factory(
         user=user, project=reviewer_report.task.project, is_reviewer=True
     )
 
@@ -370,9 +362,11 @@ def test_report_list_filter_editable_reviewer(
     assert len(json["data"]) == 3
 
 
-def test_report_list_filter_editable_superuser(superadmin_client, report_factory):
-    EmploymentFactory.create(user=superadmin_client.user)
-    report = report_factory.create()
+def test_report_list_filter_editable_superuser(
+    superadmin_client, report_factory, employment_factory
+):
+    employment_factory(user=superadmin_client.user)
+    report = report_factory()
 
     url = reverse("report-list")
 
@@ -383,9 +377,11 @@ def test_report_list_filter_editable_superuser(superadmin_client, report_factory
     assert json["data"][0]["id"] == str(report.id)
 
 
-def test_report_list_filter_not_editable_superuser(superadmin_client, report_factory):
-    EmploymentFactory.create(user=superadmin_client.user)
-    report_factory.create()
+def test_report_list_filter_not_editable_superuser(
+    superadmin_client, report_factory, employment_factory
+):
+    employment_factory(user=superadmin_client.user)
+    report_factory()
 
     url = reverse("report-list")
 
@@ -402,18 +398,18 @@ def test_report_list_filter_editable_supervisor(
 ):
     user = internal_employee_client.user
     # not editable report
-    report_factory.create()
+    report_factory()
 
     # editable reports
     # 1st case: report by current user
-    report_factory.create(user=user)
+    report_factory(user=user)
     # 2nd case: report by current user with several supervisors
-    report = report_factory.create(user=user)
+    report = report_factory(user=user)
     report.user.supervisors.add(user)
-    other_user = user_factory.create()
+    other_user = user_factory()
     report.user.supervisors.add(other_user)
     # 3rd case: report by different user with current user as supervisor
-    supervisor_report = report_factory.create()
+    supervisor_report = report_factory()
     supervisor_report.user.supervisors.add(user)
 
     url = reverse("report-list")
@@ -457,7 +453,7 @@ def test_report_detail(
     report_factory,
 ):
     user = internal_employee_client.user
-    report = report_factory.create(user=user)
+    report = report_factory(user=user)
 
     url = reverse("report-detail", args=[report.id])
     response = internal_employee_client.get(url)
@@ -482,18 +478,20 @@ def test_report_detail(
         (False, False, True, False, status.HTTP_201_CREATED),
     ],
 )
-def test_report_create(auth_client, task_factory, task_assignee, is_external, expected):
+def test_report_create(
+    auth_client, task_factory, task_assignee, is_external, expected, employment_factory
+):
     """Should create a new report and automatically set the user."""
     user = auth_client.user
-    task = task_factory.create()
+    task = task_factory()
     task_assignee.user = user
     task_assignee.task = task
     task_assignee.save()
 
     if is_external:
-        EmploymentFactory.create(user=user, is_external=True)
+        employment_factory(user=user, is_external=True)
     else:
-        EmploymentFactory.create(user=user, is_external=False)
+        employment_factory(user=user, is_external=False)
 
     data = {
         "data": {
@@ -526,8 +524,8 @@ def test_report_create(auth_client, task_factory, task_assignee, is_external, ex
 def test_report_create_billed(internal_employee_client, project_factory, task_factory):
     """Should create a new report and automatically set the user."""
     user = internal_employee_client.user
-    project = project_factory.create(billed=True)
-    task = task_factory.create(project=project)
+    project = project_factory(billed=True)
+    task = task_factory(project=project)
 
     data = {
         "data": {
@@ -563,8 +561,8 @@ def test_report_update_bulk(
     report_factory,
     task_factory,
 ):
-    report = report_factory.create(user=internal_employee_client.user)
-    task = task_factory.create(project=report.task.project)
+    report = report_factory(user=internal_employee_client.user)
+    task = task_factory(project=report.task.project)
 
     url = reverse("report-bulk")
 
@@ -587,7 +585,7 @@ def test_report_update_bulk_verify_non_reviewer(
     internal_employee_client,
     report_factory,
 ):
-    report_factory.create(user=internal_employee_client.user)
+    report_factory(user=internal_employee_client.user)
 
     url = reverse("report-bulk")
 
@@ -599,10 +597,12 @@ def test_report_update_bulk_verify_non_reviewer(
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_report_update_bulk_verify_superuser(superadmin_client, report_factory):
+def test_report_update_bulk_verify_superuser(
+    superadmin_client, report_factory, employment_factory
+):
     user = superadmin_client.user
-    EmploymentFactory.create(user=user)
-    report = report_factory.create(user=user)
+    employment_factory(user=user)
+    report = report_factory(user=user)
 
     url = reverse("report-bulk")
 
@@ -618,14 +618,11 @@ def test_report_update_bulk_verify_superuser(superadmin_client, report_factory):
 
 
 def test_report_update_bulk_verify_reviewer(
-    internal_employee_client,
-    report_factory,
+    internal_employee_client, report_factory, project_assignee_factory
 ):
     user = internal_employee_client.user
-    report = report_factory.create(user=user)
-    ProjectAssigneeFactory.create(
-        user=user, project=report.task.project, is_reviewer=True
-    )
+    report = report_factory(user=user)
+    project_assignee_factory(user=user, project=report.task.project, is_reviewer=True)
 
     url = reverse("report-bulk")
 
@@ -647,10 +644,12 @@ def test_report_update_bulk_verify_reviewer(
     assert report.comment == "some comment"
 
 
-def test_report_update_bulk_reset_verify(superadmin_client, report_factory):
+def test_report_update_bulk_reset_verify(
+    superadmin_client, report_factory, employment_factory
+):
     user = superadmin_client.user
-    EmploymentFactory.create(user=user)
-    report = report_factory.create(verified_by=user)
+    employment_factory(user=user)
+    report = report_factory(verified_by=user)
 
     url = reverse("report-bulk")
 
@@ -688,9 +687,7 @@ def test_report_update_verified_as_non_staff_but_owner(
 ):
     """Test that an owner (not staff) may not change a verified report."""
     user = internal_employee_client.user
-    report = report_factory.create(
-        user=user, verified_by=user, duration=timedelta(hours=2)
-    )
+    report = report_factory(user=user, verified_by=user, duration=timedelta(hours=2))
 
     url = reverse("report-detail", args=[report.id])
 
@@ -711,8 +708,8 @@ def test_report_update_owner(
 ):
     """Should update an existing report."""
     user = internal_employee_client.user
-    report = report_factory.create(user=user)
-    task = task_factory.create()
+    report = report_factory(user=user)
+    task = task_factory()
 
     data = {
         "data": {
@@ -748,14 +745,11 @@ def test_report_update_owner(
 
 
 def test_report_update_date_reviewer(
-    internal_employee_client,
-    report_factory,
+    internal_employee_client, report_factory, project_assignee_factory
 ):
     user = internal_employee_client.user
-    report = report_factory.create()
-    ProjectAssigneeFactory.create(
-        user=user, project=report.task.project, is_reviewer=True
-    )
+    report = report_factory()
+    project_assignee_factory(user=user, project=report.task.project, is_reviewer=True)
 
     data = {
         "data": {
@@ -772,14 +766,11 @@ def test_report_update_date_reviewer(
 
 
 def test_report_update_duration_reviewer(
-    internal_employee_client,
-    report_factory,
+    internal_employee_client, report_factory, project_assignee_factory
 ):
     user = internal_employee_client.user
-    report = report_factory.create(duration=timedelta(hours=2))
-    ProjectAssigneeFactory.create(
-        user=user, project=report.task.project, is_reviewer=True
-    )
+    report = report_factory(duration=timedelta(hours=2))
+    project_assignee_factory(user=user, project=report.task.project, is_reviewer=True)
 
     data = {
         "data": {
@@ -800,7 +791,7 @@ def test_report_update_by_user(
     report_factory,
 ):
     """Updating of report belonging to different user is not allowed."""
-    report = report_factory.create()
+    report = report_factory()
     data = {
         "data": {
             "type": "reports",
@@ -815,14 +806,11 @@ def test_report_update_by_user(
 
 
 def test_report_update_verified_and_review_reviewer(
-    internal_employee_client,
-    report_factory,
+    internal_employee_client, report_factory, project_assignee_factory
 ):
     user = internal_employee_client.user
-    report = report_factory.create(duration=timedelta(hours=2))
-    ProjectAssigneeFactory.create(
-        user=user, project=report.task.project, is_reviewer=True
-    )
+    report = report_factory(duration=timedelta(hours=2))
+    project_assignee_factory(user=user, project=report.task.project, is_reviewer=True)
 
     data = {
         "data": {
@@ -847,7 +835,7 @@ def test_report_set_verified_by_user(
 ):
     """Test that normal user may not verify report."""
     user = internal_employee_client.user
-    report = report_factory.create(user=user)
+    report = report_factory(user=user)
     data = {
         "data": {
             "type": "reports",
@@ -864,15 +852,11 @@ def test_report_set_verified_by_user(
 
 
 def test_report_update_reviewer(
-    internal_employee_client,
-    report_factory,
-    mailoutbox,
+    internal_employee_client, report_factory, mailoutbox, project_assignee_factory
 ):
     user = internal_employee_client.user
-    report = report_factory.create(user=user)
-    ProjectAssigneeFactory.create(
-        user=user, project=report.task.project, is_reviewer=True
-    )
+    report = report_factory(user=user)
+    project_assignee_factory(user=user, project=report.task.project, is_reviewer=True)
 
     data = {
         "data": {
@@ -897,7 +881,7 @@ def test_report_update_supervisor(
     report_factory,
 ):
     user = internal_employee_client.user
-    report = report_factory.create(user=user)
+    report = report_factory(user=user)
     report.user.supervisors.add(user)
 
     data = {
@@ -914,11 +898,13 @@ def test_report_update_supervisor(
     assert response.status_code == status.HTTP_200_OK
 
 
-def test_report_verify_other_user(superadmin_client, report_factory, user_factory):
+def test_report_verify_other_user(
+    superadmin_client, report_factory, user_factory, employment_factory
+):
     """Verify that superuser may not verify to other user."""
-    EmploymentFactory.create(user=superadmin_client.user)
-    user = user_factory.create()
-    report = report_factory.create()
+    employment_factory(user=superadmin_client.user)
+    user = user_factory()
+    report = report_factory()
 
     data = {
         "data": {
@@ -936,14 +922,13 @@ def test_report_verify_other_user(superadmin_client, report_factory, user_factor
 
 
 def test_report_reset_verified_by_reviewer(
-    internal_employee_client,
-    report_factory,
+    internal_employee_client, report_factory, project_assignee_factory, user_factory
 ):
     """Test that reviewer may not change verified report."""
     user = internal_employee_client.user
-    reviewer = UserFactory.create()
-    report = report_factory.create(user=user, verified_by=reviewer)
-    ProjectAssigneeFactory.create(
+    reviewer = user_factory()
+    report = report_factory(user=user, verified_by=reviewer)
+    project_assignee_factory(
         user=reviewer, project=report.task.project, is_reviewer=True
     )
 
@@ -965,15 +950,12 @@ def test_report_reset_verified_by_reviewer(
 
 
 def test_report_reset_verified_and_billed_by_reviewer(
-    internal_employee_client,
-    report_factory,
+    internal_employee_client, report_factory, project_assignee_factory
 ):
     """Test that reviewer may not change verified and billed report."""
     user = internal_employee_client.user
-    report = report_factory.create(user=user, verified_by=user)
-    ProjectAssigneeFactory.create(
-        user=user, project=report.task.project, is_reviewer=True
-    )
+    report = report_factory(user=user, verified_by=user)
+    project_assignee_factory(user=user, project=report.task.project, is_reviewer=True)
     # Billed is not set on create because the factory doesnt seem to work with that
     report.billed = True
     report.save()
@@ -1017,21 +999,28 @@ def test_report_reset_verified_and_billed_by_reviewer(
     ],
 )
 def test_report_delete_own_report(
-    auth_client, report_factory, task_assignee, is_external, verified, expected
+    auth_client,
+    report_factory,
+    task_assignee,
+    is_external,
+    verified,
+    expected,
+    employment_factory,
+    user_factory,
 ):
     user = auth_client.user
     task_assignee.user = user
     task_assignee.save()
-    report = report_factory.create(user=user, task=task_assignee.task)
+    report = report_factory(user=user, task=task_assignee.task)
 
     if verified:
-        report.verified_by = UserFactory.create()
+        report.verified_by = user_factory()
         report.save()
 
     if is_external:
-        EmploymentFactory.create(user=user, is_external=True)
+        employment_factory(user=user, is_external=True)
     else:
-        EmploymentFactory.create(user=user, is_external=False)
+        employment_factory(user=user, is_external=False)
 
     url = reverse("report-detail", args=[report.id])
     response = auth_client.delete(url)
@@ -1062,23 +1051,29 @@ def test_report_delete_own_report(
     ],
 )
 def test_report_delete_not_report_owner(
-    auth_client, report_factory, task_assignee, is_external, verified
+    auth_client,
+    report_factory,
+    task_assignee,
+    is_external,
+    verified,
+    employment_factory,
+    user_factory,
 ):
     user = auth_client.user
     task_assignee.user = user
     task_assignee.save()
 
-    user2 = UserFactory.create()
-    report = report_factory.create(user=user2, task=task_assignee.task)
+    user2 = user_factory()
+    report = report_factory(user=user2, task=task_assignee.task)
 
     if verified:
-        report.verified_by = UserFactory.create()
+        report.verified_by = user_factory()
         report.save()
 
     if is_external:
-        EmploymentFactory.create(user=user, is_external=True)
+        employment_factory(user=user, is_external=True)
     else:
-        EmploymentFactory.create(user=user, is_external=False)
+        employment_factory(user=user, is_external=False)
 
     url = reverse("report-detail", args=[report.id])
     response = auth_client.delete(url)
@@ -1093,7 +1088,7 @@ def test_report_delete_not_report_owner(
 @pytest.mark.django_db
 def test_report_round_duration(report_factory):
     """Should round the duration of a report to 15 minutes."""
-    report = report_factory.create()
+    report = report_factory()
 
     report.duration = timedelta(hours=1, minutes=7)
     report.save()
@@ -1111,8 +1106,8 @@ def test_report_round_duration(report_factory):
     assert duration_string(report.duration) == "02:00:00"
 
 
-def test_report_list_no_result(admin_client):
-    EmploymentFactory.create(user=admin_client.user)
+def test_report_list_no_result(admin_client, employment_factory):
+    employment_factory(user=admin_client.user)
     url = reverse("report-list")
     res = admin_client.get(url)
 
@@ -1121,10 +1116,10 @@ def test_report_list_no_result(admin_client):
     assert json["meta"]["total-time"] == "00:00:00"
 
 
-def test_report_delete_superuser(superadmin_client, report_factory):
+def test_report_delete_superuser(superadmin_client, report_factory, employment_factory):
     """Test that superuser may not delete reports of other users."""
-    EmploymentFactory.create(user=superadmin_client.user)
-    report = report_factory.create()
+    employment_factory(user=superadmin_client.user)
+    report = report_factory()
     url = reverse("report-detail", args=[report.id])
 
     response = superadmin_client.delete(url)
@@ -1138,19 +1133,19 @@ def test_report_list_filter_cost_center(
     project_factory,
     task_factory,
 ):
-    cost_center = cost_center_factory.create()
+    cost_center = cost_center_factory()
     # 1st valid case: report with task of given cost center
     # but different project cost center
-    task = task_factory.create(cost_center=cost_center)
-    report_task = report_factory.create(task=task)
+    task = task_factory(cost_center=cost_center)
+    report_task = report_factory(task=task)
     # 2nd valid case: report with project of given cost center
-    project = project_factory.create(cost_center=cost_center)
-    task = task_factory.create(cost_center=None, project=project)
-    report_project = report_factory.create(task=task)
+    project = project_factory(cost_center=cost_center)
+    task = task_factory(cost_center=None, project=project)
+    report_project = report_factory(task=task)
     # Invalid case: report without cost center
-    project = project_factory.create(cost_center=None)
-    task = task_factory.create(cost_center=None, project=project)
-    report_factory.create(task=task)
+    project = project_factory(cost_center=None)
+    task = task_factory(cost_center=None, project=project)
+    report_factory(task=task)
 
     url = reverse("report-list")
 
@@ -1329,6 +1324,8 @@ def test_report_update_reviewer_notify(
     different_attributes,
     verified,
     expected,
+    project_assignee_factory,
+    task_assignee_factory,
 ):
     reviewer = internal_employee_client.user
     user = user_factory()
@@ -1337,16 +1334,14 @@ def test_report_update_reviewer_notify(
         report = report_factory(user=reviewer, review=True)
     else:
         report = report_factory(user=user, review=True)
-    ProjectAssigneeFactory.create(
+    project_assignee_factory(
         user=reviewer, project=report.task.project, is_reviewer=True
     )
-    ProjectAssigneeFactory.create(
-        user=user, project=report.task.project, is_reviewer=True
-    )
+    project_assignee_factory(user=user, project=report.task.project, is_reviewer=True)
     new_task = task_factory(project=report.task.project)
     task = report.task
-    TaskAssigneeFactory.create(user=user, is_resource=True, task=task)
-    TaskAssigneeFactory.create(user=reviewer, is_reviewer=True, task=task)
+    task_assignee_factory(user=user, is_resource=True, task=task)
+    task_assignee_factory(user=reviewer, is_reviewer=True, task=task)
 
     data = {
         "data": {
@@ -1390,10 +1385,11 @@ def test_report_notify_rendering(
     task_factory,
     mailoutbox,
     snapshot,
+    project_assignee_factory,
 ):
     reviewer = internal_employee_client.user
     user = user_factory()
-    ProjectAssigneeFactory.create(user=reviewer, project=project, is_reviewer=True)
+    project_assignee_factory(user=reviewer, project=project, is_reviewer=True)
     task1, task2, task3 = task_factory.create_batch(3, project=project)
 
     report1 = report_factory(
@@ -1450,9 +1446,9 @@ def test_report_notify_rendering(
     ("report__review", "needs_review"), [(True, False), (False, True), (True, True)]
 )
 def test_report_update_bulk_review_and_verified(
-    superadmin_client, report, needs_review
+    superadmin_client, report, needs_review, employment_factory
 ):
-    EmploymentFactory.create(user=superadmin_client.user)
+    employment_factory(user=superadmin_client.user)
     data = {
         "data": {"type": "report-bulks", "id": None, "attributes": {"verified": True}}
     }
@@ -1471,7 +1467,7 @@ def test_report_update_bulk_bill_non_reviewer(
     internal_employee_client,
     report_factory,
 ):
-    report_factory.create(user=internal_employee_client.user)
+    report_factory(user=internal_employee_client.user)
 
     url = reverse("report-bulk")
 
@@ -1482,14 +1478,11 @@ def test_report_update_bulk_bill_non_reviewer(
 
 
 def test_report_update_bulk_bill_reviewer(
-    internal_employee_client,
-    report_factory,
+    internal_employee_client, report_factory, project_assignee_factory
 ):
     user = internal_employee_client.user
-    report = report_factory.create(user=user)
-    ProjectAssigneeFactory.create(
-        user=user, project=report.task.project, is_reviewer=True
-    )
+    report = report_factory(user=user)
+    project_assignee_factory(user=user, project=report.task.project, is_reviewer=True)
 
     url = reverse("report-bulk")
 
@@ -1517,7 +1510,7 @@ def test_report_update_bulk_bill_accountant(
     user = internal_employee_client.user
     user.is_accountant = True
     user.save()
-    report = report_factory.create(user=user)
+    report = report_factory(user=user)
     url = reverse("report-bulk")
 
     data = {
@@ -1539,7 +1532,7 @@ def test_report_update_billed_user(
     internal_employee_client,
     report_factory,
 ):
-    report = report_factory.create()
+    report = report_factory()
 
     data = {
         "data": {
@@ -1573,7 +1566,7 @@ def test_report_set_billed_by_user(
     if is_accountant:
         user.is_accountant = True
         user.save()
-    report = report_factory.create(user=user)
+    report = report_factory(user=user)
     data = {
         "data": {
             "type": "reports",
@@ -1589,7 +1582,7 @@ def test_report_set_billed_by_user(
 
 def test_report_update_billed(internal_employee_client, report_factory, task):
     user = internal_employee_client.user
-    report = report_factory.create(user=user, billed=True)
+    report = report_factory(user=user, billed=True)
     report.task.project.billed = True
     report.task.project.save()
 
@@ -1663,10 +1656,12 @@ def test_report_update_bulk_billed(
     assert report.billed
 
 
-def test_report_list_external_employee(external_employee_client, report_factory):
+def test_report_list_external_employee(
+    external_employee_client, report_factory, task_assignee_factory
+):
     user = external_employee_client.user
-    report = report_factory.create(user=user, duration=timedelta(hours=1))
-    TaskAssigneeFactory.create(user=user, task=report.task, is_resource=True)
+    report = report_factory(user=user, duration=timedelta(hours=1))
+    task_assignee_factory(user=user, task=report.task, is_resource=True)
     report_factory.create_batch(4)
     url = reverse("report-list")
 
@@ -1695,12 +1690,17 @@ def test_report_list_external_employee(external_employee_client, report_factory)
     [(True, 1, status.HTTP_200_OK), (False, 0, status.HTTP_403_FORBIDDEN)],
 )
 def test_report_list_no_employment(
-    auth_client, report_factory, is_assigned, expected, status_code
+    auth_client,
+    report_factory,
+    is_assigned,
+    expected,
+    status_code,
+    customer_assignee_factory,
 ):
     user = auth_client.user
-    report = report_factory.create(user=user, duration=timedelta(hours=1))
+    report = report_factory(user=user, duration=timedelta(hours=1))
     if is_assigned:
-        CustomerAssigneeFactory.create(
+        customer_assignee_factory(
             user=user, is_customer=True, customer=report.task.project.customer
         )
     report_factory.create_batch(4)
@@ -1735,12 +1735,14 @@ def test_report_reject(
     status_code,
     mail_count,
     mailoutbox,
+    project_assignee_factory,
+    user_factory,
 ):
     user = internal_employee_client.user
-    user2 = UserFactory.create()
-    report = report_factory.create(user=user2 if not report_owner else user)
+    user2 = user_factory()
+    report = report_factory(user=user2 if not report_owner else user)
     if reviewer:
-        ProjectAssigneeFactory.create(
+        project_assignee_factory(
             user=user, is_reviewer=True, project=report.task.project
         )
 
@@ -1770,7 +1772,7 @@ def test_report_update_rejected_owner(
     internal_employee_client, report_factory, mailoutbox
 ):
     user = internal_employee_client.user
-    report = report_factory.create(user=user, rejected=True)
+    report = report_factory(user=user, rejected=True)
 
     data = {
         "data": {
@@ -1840,7 +1842,7 @@ def test_report_reject_multiple_notify(
 
 def test_report_automatic_unreject(internal_employee_client, report_factory, task):
     user = internal_employee_client.user
-    report = report_factory.create(user=user, rejected=True)
+    report = report_factory(user=user, rejected=True)
 
     data = {
         "data": {
@@ -1867,7 +1869,7 @@ def test_report_bulk_automatic_unreject(
 ):
     reviewer = internal_employee_client.user
 
-    report = report_factory.create(user=user, rejected=True, task__project=task.project)
+    report = report_factory(user=user, rejected=True, task__project=task.project)
 
     project_assignee_factory(
         user=reviewer, project=report.task.project, is_reviewer=True
@@ -1911,10 +1913,11 @@ def test_report_set_remaining_effort(
     expected,
     is_superuser,
     report_factory,
+    employment_factory,
 ):
     user = auth_client.user
-    EmploymentFactory.create(user=user, is_external=is_external)
-    report = report_factory.create(user=user)
+    employment_factory(user=user, is_external=is_external)
+    report = report_factory(user=user)
 
     if remaining_effort_active:
         report.task.project.remaining_effort_tracking = True
@@ -1949,10 +1952,10 @@ def test_report_create_remaining_effort(
     remaining_effort_active,
 ):
     user = internal_employee_client.user
-    project = project_factory.create(
+    project = project_factory(
         billed=True, remaining_effort_tracking=remaining_effort_active
     )
-    task = task_factory.create(project=project)
+    task = task_factory(project=project)
 
     data = {
         "data": {
@@ -1990,13 +1993,12 @@ def test_report_create_remaining_effort(
 
 
 def test_report_remaining_effort_total(
-    internal_employee_client,
-    report_factory,
+    internal_employee_client, report_factory, task_factory
 ):
     user = internal_employee_client.user
-    report = report_factory.create(user=user)
-    task_2 = TaskFactory.create(project=report.task.project)
-    report_2 = report_factory.create(user=user, task=task_2)
+    report = report_factory(user=user)
+    task_2 = task_factory(project=report.task.project)
+    report_2 = report_factory(user=user, task=task_2)
     report.task.project.remaining_effort_tracking = True
     report.task.project.save()
 
@@ -2044,8 +2046,8 @@ def test_report_remaining_effort_update(
     report_factory,
 ):
     user = internal_employee_client.user
-    report = report_factory.create(user=user, date="2022-02-01")
-    report_2 = report_factory.create(user=user, task=report.task, date="2022-02-01")
+    report = report_factory(user=user, date="2022-02-01")
+    report_2 = report_factory(user=user, task=report.task, date="2022-02-01")
     report.task.project.remaining_effort_tracking = True
     report.task.project.save()
 
@@ -2111,9 +2113,9 @@ def test_report_list_filter_comment(
     internal_employee_client,
     report_factory,
 ):
-    report_1 = report_factory.create(comment="review thing with Test User")
-    report_2 = report_factory.create(comment="help Test User setup their laptop")
-    report_3 = report_factory.create(comment="created LDAP account for Test User")
+    report_1 = report_factory(comment="review thing with Test User")
+    report_2 = report_factory(comment="help Test User setup their laptop")
+    report_3 = report_factory(comment="created LDAP account for Test User")
     report_factory(comment="nothing related to the other comments")
 
     url = reverse("report-list")


### PR DESCRIPTION
migrate old/legacy tests to pytest-factoryboy fixtures

automated with `libcst`, see gebastel below:

```py
import subprocess
from operator import attrgetter
from pathlib import Path

import inflection
import libcst as cst
from libcst.metadata import (
    FunctionScope,
    ScopeProvider,
)
from libcst.metadata.scope_provider import _gen_dotted_names

pyproject_root = Path("../timed/backend").resolve()
project_root = pyproject_root / "timed"
proj_files = set(project_root.glob("**/*.py"))
test_files = {f for f in proj_files if "tests" in f.parts}
test_files.add(pyproject_root / "conftest.py")

class Transformer(cst.CSTTransformer):
    METADATA_DEPENDENCIES = (ScopeProvider,)

    def __init__(self) -> None:
        self.fixtures_to_add: dict[cst.Parameters, set[str]] = {}

    def leave_Call(self, original_node: cst.Call, updated_node: cst.Call) -> cst.Call:
        fn = original_node.func
        scope = self.get_metadata(ScopeProvider, original_node)
        if not isinstance(scope, FunctionScope):
            return updated_node

        scope: FunctionScope
        name = next(iter(scope.get_qualified_names_for(fn))).name
        expr = None

        # `some_factory.create(x=y)` is equivalent to `some_factory(x=y)`
        if name.endswith("actory.create"):
            expr = next(_gen_dotted_names(fn))[0]  # ty:ignore[invalid-argument-type]
            expr = expr.removesuffix(".create")
            updated_node = updated_node.with_changes(func=cst.parse_expression(expr))

        if "factories" not in name:
            return updated_node

        # get the function (the path to it) as string if we haven't already done that
        if expr is None:
            expr = next(_gen_dotted_names(fn))[0]  # ty:ignore[invalid-argument-type]

        # rewrite the calls
        factory_name = next(s for s in name.split(".") if s.endswith("Factory"))

        # we remove anything before the `SomeFactory`
        # and then fix the casing
        expr = (fixture_name := inflection.underscore(factory_name)) + expr.split(
            factory_name
        )[1]

        # record the function signature having changed/requiring more/new fixtures
        fndef: cst.FunctionDef = scope.node
        params = fndef.params
        if fixture_name not in map(attrgetter("name.value"), params.params):
            self.fixtures_to_add.setdefault(params, set()).add(fixture_name)

        return updated_node.with_changes(func=cst.parse_expression(expr))

    def leave_FunctionDef(
        self,
        original_node: cst.FunctionDef,
        updated_node: cst.FunctionDef,
    ) -> cst.FunctionDef:
        """add fixtures to functions"""

        if not (params_to_add := self.fixtures_to_add.get(original_node.params)):
            return updated_node
        return updated_node.with_deep_changes(
            updated_node.params,
            params=(
                *updated_node.params.params,
                *(cst.Param(cst.Name(p)) for p in sorted(params_to_add)),
            ),
        )

for file in test_files:
    print(file)

    module = cst.parse_module(pre := file.read_text())
    wrapper = cst.metadata.MetadataWrapper(module)

    rendered = wrapper.visit(Transformer())

    file.write_text(rendered.code)
    subprocess.run(
        ["ruff", "check", "--fix", "--select", "I,F401", file.absolute()], check=True
    )
    subprocess.run(["ruff", "format", file.absolute()], check=True)
```