### PR TITLE
fix(frontend): prevent balance chart crash on missing timesheet

### DIFF
--- a/ember/frontend/app/users/edit/index/template.gjs
+++ b/ember/frontend/app/users/edit/index/template.gjs
@@ -22,33 +22,33 @@ import luxonFormat from "timed/helpers/luxon-format";
           <tbody class="[&>tr>td:last-child]:text-right [&>tr>td]:py-1">
             <tr>
               <td>Email:</td>
-              <td>{{@controller.model.email}}</td>
+              <td>{{@model.email}}</td>
             </tr>
             <tr>
               <td>Username:</td>
-              <td>{{@controller.model.username}}</td>
+              <td>{{@model.username}}</td>
             </tr>
-            {{#if @controller.model.activeEmployment}}
+            {{#if @model.activeEmployment}}
               <tr>
                 <td>Location:</td>
-                <td>{{@controller.model.activeEmployment.location.name}}</td>
+                <td>{{@model.activeEmployment.location.name}}</td>
               </tr>
               <tr>
                 <td>Contract type:</td>
                 <td>{{if
-                    @controller.model.activeEmployment.isExternal
+                    @model.activeEmployment.isExternal
                     "External"
                     "Internal"
                   }}</td>
               </tr>
               <tr>
                 <td>Percentage:</td>
-                <td>{{@controller.model.activeEmployment.percentage}}%</td>
+                <td>{{@model.activeEmployment.percentage}}%</td>
               </tr>
               <tr>
                 <td>Worktime:</td>
                 <td>{{humanizeDuration
-                    @controller.model.activeEmployment.worktimePerDay
+                    @model.activeEmployment.worktimePerDay
                     false
                   }}</td>
               </tr>

--- a/ember/frontend/app/users/edit/template.gjs
+++ b/ember/frontend/app/users/edit/template.gjs
@@ -1,5 +1,6 @@
 import { LinkTo } from "@ember/routing";
 import can from "ember-can/helpers/can";
+import { or } from "ember-truth-helpers";
 
 import BalanceDonut from "timed/components/balance-donut";
 import LoadingIcon from "timed/components/loading-icon";
@@ -44,7 +45,10 @@ import media from "timed/helpers/media";
                   title="Last day with timesheet entries or absences"
                   class="text-foreground-muted text-base uppercase sm:text-lg md:text-xl lg:text-2xl"
                 >
-                  {{luxonFormat balance.date "dd.MM.yyyy"}}
+                  {{luxonFormat
+                    (or balance.date @model.activeEmployment.start)
+                    "dd.MM.yyyy"
+                  }}
                 </h2>
                 <div
                   class="{{balanceHighlightClass balance.balance}}

--- a/ember/frontend/app/users/edit/template.gjs
+++ b/ember/frontend/app/users/edit/template.gjs
@@ -10,13 +10,14 @@ import balanceHighlightClass from "timed/helpers/balance-highlight-class";
 import formatDuration from "timed/helpers/format-duration";
 import luxonFormat from "timed/helpers/luxon-format";
 import media from "timed/helpers/media";
+
 <template>
-  {{#if (can "read user" @controller.model)}}
+  {{#if (can "read user" @model)}}
     <header class="user-header grid border-b">
       <div class="user-header-info">
         <h1
           class="text-foreground text-center text-5xl md:text-6xl"
-        >{{@controller.model.fullName}}</h1>
+        >{{@model.fullName}}</h1>
       </div>
 
       {{#if @controller.data.isRunning}}
@@ -26,7 +27,7 @@ import media from "timed/helpers/media";
           <LoadingIcon />
         </div>
       {{else}}
-        {{#unless @controller.model.activeEmployment.isExternal}}
+        {{#unless @model.activeEmployment.isExternal}}
           <h2
             class="user-header-worktime-balance-title text-foreground-muted text-center text-2xl uppercase md:text-3xl"
           >Worktime balance</h2>
@@ -124,15 +125,15 @@ import media from "timed/helpers/media";
       >
         <li><LinkTo
             @route="users.edit.index"
-            @model={{@controller.model.id}}
+            @model={{@model.id}}
           >General</LinkTo></li>
         <li><LinkTo
             @route="users.edit.credits"
-            @model={{@controller.model.id}}
+            @model={{@model.id}}
           >Credits</LinkTo></li>
         <li><LinkTo
             @route="users.edit.responsibilities"
-            @model={{@controller.model.id}}
+            @model={{@model.id}}
           >Responsibilities</LinkTo></li>
       </ul>
     </nav>


### PR DESCRIPTION
display the start of the active deployment if a user has no valid last timesheet

before migrating to luxon, this would display the current date, as the [`moment-format` helper](https://github.com/adopted-ember-addons/ember-moment/blob/master/ember-moment/src/helpers/moment-format.js#L40) called `moment(input)` (which was `undefined` in this case, and `fn(undefined)` is equivalent to `fn()` in javascript) 