### PR TITLE
Filter reports by multiple users

### DIFF
--- a/backend/timed/reports/filters.py
+++ b/backend/timed/reports/filters.py
@@ -11,6 +11,7 @@ from django_filters.rest_framework import (
     NumberFilter,
 )
 
+from timed.projects.filters import NumberInFilter
 from timed.projects.models import CustomerAssignee, ProjectAssignee, TaskAssignee
 
 if TYPE_CHECKING:
@@ -141,7 +142,7 @@ def statistic_filterset_builder(
             ),
             "verifier": NumberFilter(field_name=f"{reports_prefix}verified_by"),
             "billing_type": NumberFilter(field_name=f"{project_prefix}billing_type"),
-            "user": NumberFilter(field_name=f"{reports_prefix}user_id"),
+            "user": NumberInFilter(field_name=f"{reports_prefix}user_id"),
             "rejected": NumberFilter(field_name=f"{reports_prefix}rejected"),
             "id": BaseInFilter(),
             "cost_center": NumberFilter(method="filter_cost_center"),

--- a/backend/timed/reports/tests/test_user_statistic.py
+++ b/backend/timed/reports/tests/test_user_statistic.py
@@ -4,6 +4,7 @@ import pytest
 from django.urls import reverse
 from rest_framework import status
 
+from timed.employment.factories import UserFactory
 from timed.tracking.factories import ReportFactory
 
 
@@ -64,3 +65,22 @@ def test_user_statistic_list(
         assert json["data"] == expected_json
         assert len(json["included"]) == 2
         assert json["meta"]["total-time"] == "05:00:00"
+
+
+def test_user_statistic_filter_multiple_users(internal_employee_client):
+    """The user statistics endpoint filters by a comma separated user list."""
+    user_a = UserFactory.create()
+    user_b = UserFactory.create()
+    user_c = UserFactory.create()
+    ReportFactory.create(duration=timedelta(hours=1), user=user_a)
+    ReportFactory.create(duration=timedelta(hours=2), user=user_b)
+    ReportFactory.create(duration=timedelta(hours=3), user=user_c)
+
+    url = reverse("user-statistic-list")
+    result = internal_employee_client.get(
+        url, data={"user": f"{user_a.id},{user_b.id}", "include": "user"}
+    )
+
+    assert result.status_code == status.HTTP_200_OK
+    returned_ids = {item["id"] for item in result.json()["data"]}
+    assert returned_ids == {str(user_a.id), str(user_b.id)}

--- a/backend/timed/tracking/filters.py
+++ b/backend/timed/tracking/filters.py
@@ -18,6 +18,7 @@ from django_filters.rest_framework import (
     NumberFilter,
 )
 
+from timed.projects.filters import NumberInFilter
 from timed.projects.models import CustomerAssignee, ProjectAssignee, TaskAssignee
 from timed.tracking import models
 
@@ -112,7 +113,7 @@ class ReportFilterSet(FilterSet):
     reviewer = NumberFilter(method="filter_has_reviewer")
     verifier = NumberFilter(field_name="verified_by")
     billing_type = NumberFilter(field_name="task__project__billing_type")
-    user = NumberFilter(field_name="user_id")
+    user = NumberInFilter(field_name="user_id")
     cost_center = NumberFilter(method="filter_cost_center")
     rejected = NumberFilter(field_name="rejected")
     comment = CharFilter(method="filter_comment")

--- a/backend/timed/tracking/tests/test_report.py
+++ b/backend/timed/tracking/tests/test_report.py
@@ -2241,3 +2241,37 @@ def test_report_bulk_customer_change_requires_review_comment(
 
     report.refresh_from_db()
     assert report.task != task
+
+
+def test_report_list_filter_multiple_users(internal_employee_client, report_factory):
+    """The user filter accepts a comma separated list of user ids."""
+    user_a = UserFactory.create()
+    user_b = UserFactory.create()
+    user_c = UserFactory.create()
+    report_a = report_factory.create(user=user_a)
+    report_b = report_factory.create(user=user_b)
+    report_factory.create(user=user_c)
+    url = reverse("report-list")
+
+    response = internal_employee_client.get(
+        url, data={"user": f"{user_a.id},{user_b.id}"}
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    returned_ids = {item["id"] for item in response.json()["data"]}
+    assert returned_ids == {str(report_a.id), str(report_b.id)}
+
+
+def test_report_list_filter_single_user(internal_employee_client, report_factory):
+    """A single user id keeps working with the comma separated filter."""
+    user_a = UserFactory.create()
+    user_b = UserFactory.create()
+    report_a = report_factory.create(user=user_a)
+    report_factory.create(user=user_b)
+    url = reverse("report-list")
+
+    response = internal_employee_client.get(url, data={"user": str(user_a.id)})
+
+    assert response.status_code == status.HTTP_200_OK
+    returned_ids = {item["id"] for item in response.json()["data"]}
+    assert returned_ids == {str(report_a.id)}

--- a/frontend/app/analysis/index/controller.js
+++ b/frontend/app/analysis/index/controller.js
@@ -105,8 +105,13 @@ export default class AnalysisController extends QPController {
     return this.task && this.store.peekRecord("task", this.task);
   }
 
-  get selectedUser() {
-    return this.user && this.store.peekRecord("user", this.user);
+  get selectedUsers() {
+    return this.user
+      ? this.user
+          .split(",")
+          .map((id) => this.store.peekRecord("user", id))
+          .filter(Boolean)
+      : [];
   }
 
   get selectedReviewer() {
@@ -150,6 +155,15 @@ export default class AnalysisController extends QPController {
   }
 
   @action
+  setModelsFilter(key, value) {
+    // store the selected ids as a comma separated list, matching both the
+    // URL query param and the API's `user=1,2` filter format
+    this[key] =
+      value && value.length ? value.map((m) => m.id).join(",") : undefined;
+    this._reset();
+  }
+
+  @action
   setModelFilterOnChange(key, event) {
     this[key] = event.target.value ? event.target.value : undefined;
     this._reset();
@@ -188,7 +202,11 @@ export default class AnalysisController extends QPController {
       customer: customerId && this.store.findRecord("customer", customerId),
       project: projectId && this.store.findRecord("project", projectId),
       task: taskId && this.store.findRecord("task", taskId),
-      user: userId && this.store.findRecord("user", userId),
+      user:
+        userId &&
+        Promise.all(
+          userId.split(",").map((id) => this.store.findRecord("user", id)),
+        ),
       reviewer: reviewerId && this.store.findRecord("user", reviewerId),
       billingTypes: this.store.findAll("billing-type"),
       costCenters: this.store.findAll("cost-center"),

--- a/frontend/app/analysis/index/template.hbs
+++ b/frontend/app/analysis/index/template.hbs
@@ -52,13 +52,15 @@
           </fs.group>
           <fs.group @label="Responsibility">
             <fs.filter @label="User" data-test-filter-user>
-              <UserSelection
-                @user={{this.selectedUser}}
-                @onChange={{fn this.setModelFilter "user"}}
+              <UserSelectionMultiple
+                @users={{this.selectedUsers}}
+                @onChange={{fn this.setModelsFilter "user"}}
                 as |u|
               >
-                <u.user />
-              </UserSelection>
+                <u.user as |user|>
+                  {{user.longName}}
+                </u.user>
+              </UserSelectionMultiple>
             </fs.filter>
 
             <fs.filter @label="Reviewer" data-test-filter-reviewer>

--- a/frontend/app/components/user-selection-multiple.hbs
+++ b/frontend/app/components/user-selection-multiple.hbs
@@ -1,0 +1,15 @@
+{{yield
+  (hash
+    user=(component
+      (ensure-safe-component "power-select-multiple")
+      options=this.users
+      disabled=@disabled
+      selected=@users
+      placeholder="Select users..."
+      searchField="longName"
+      triggerClass="user-select rounded"
+      allowClear=true
+      onChange=@onChange
+    )
+  )
+}}

--- a/frontend/app/components/user-selection-multiple.js
+++ b/frontend/app/components/user-selection-multiple.js
@@ -1,0 +1,3 @@
+import UserSelection from "timed/components/user-selection";
+
+export default class UserSelectionMultiple extends UserSelection {}

--- a/frontend/tests/acceptance/analysis-test.js
+++ b/frontend/tests/acceptance/analysis-test.js
@@ -93,6 +93,45 @@ module("Acceptance | analysis", function (hooks) {
     assert.strictEqual(currentURL(), "/analysis?ordering=-user__username");
   });
 
+  test("can filter by multiple users", async function (assert) {
+    const user2 = this.server.create("user");
+    this.server.createList("report", 5, { userId: user2.id });
+
+    await visit("/analysis");
+
+    // select two distinct users in the multi-select user filter
+    await selectChoose(
+      "[data-test-filter-user] .user-select",
+      ".ember-power-select-option",
+      0,
+    );
+    await selectChoose(
+      "[data-test-filter-user] .user-select",
+      ".ember-power-select-option",
+      1,
+    );
+
+    assert
+      .dom("[data-test-filter-user] .ember-power-select-multiple-option")
+      .exists({ count: 2 }, "both selected users show as pills");
+
+    const userParam = decodeURIComponent(currentURL().match(/user=([^&]+)/)[1]);
+    assert.ok(
+      userParam.includes(","),
+      `the user query param is a comma separated list (got "${userParam}")`,
+    );
+  });
+
+  test("shows multiple users from an initial url", async function (assert) {
+    const user2 = this.server.create("user");
+
+    await visit(`/analysis?user=${this.user.id},${user2.id}`);
+
+    assert
+      .dom("[data-test-filter-user] .ember-power-select-multiple-option")
+      .exists({ count: 2 }, "both users from the url show as pills");
+  });
+
   test("can have initial filters", async function (assert) {
     const params = {
       customer: this.server.create("customer").id,
@@ -125,7 +164,7 @@ module("Acceptance | analysis", function (hooks) {
       .dom("[data-test-filter-task] .ember-power-select-selected-item")
       .exists();
     assert
-      .dom("[data-test-filter-user] .ember-power-select-selected-item")
+      .dom("[data-test-filter-user] .ember-power-select-multiple-option")
       .exists();
     assert
       .dom("[data-test-filter-reviewer] .ember-power-select-selected-item")


### PR DESCRIPTION
Lets you filter reports and statistics by more than one user at once, e.g. `?user=515,616` in the API, instead of just a single user. The analysis page user filter is now a multi-select.

Single-user filtering behaves exactly as before — it reuses the `NumberInFilter` that's already used for other filters in the project.

Backend and frontend tests included.
