### PR TITLE
fix(ui-core/durationpicker): allow empty values

### DIFF
--- a/ember/frontend/tests/acceptance/magic-link-test.js
+++ b/ember/frontend/tests/acceptance/magic-link-test.js
@@ -115,4 +115,18 @@ module("Acceptance | magic links", function (hooks) {
     assert.dom("[data-test-magic-link-comment]").hasNoValue();
     assert.dom("[data-test-magic-link-duration]").hasValue("00:00");
   });
+
+  test("draft reports can be created without a specific duration", async function (assert) {
+    await visit(
+      "/reports?task=2&comment=some+great+comment&review=true&notBillable=true",
+    );
+
+    // sanity check
+    assert.dom("[data-test-report-row]").exists({ count: 6 });
+
+    // this should be empty, and not "00:00", "00:15" or "--:--"
+    assert
+      .dom("[data-test-report-row]:last-child [data-test-report-duration]")
+      .hasNoValue();
+  });
 });

--- a/ember/ui-core/demo-app/templates/index.gts
+++ b/ember/ui-core/demo-app/templates/index.gts
@@ -25,7 +25,7 @@ class Report {
   @tracked declare project: string;
   @tracked declare task: string;
   @tracked declare comment: string;
-  @tracked declare duration: Duration;
+  @tracked declare duration: Duration | null;
   @tracked declare needsReview: boolean;
   @tracked declare notBillable: boolean;
 

--- a/ember/ui-core/src/components/ui-durationpicker.gts
+++ b/ember/ui-core/src/components/ui-durationpicker.gts
@@ -25,11 +25,11 @@ import type { TOC } from "@ember/component/template-only";
 
 export interface BaseDurationpickerSignature {
   Args: {
-    value: Duration;
-    onChange: (newValue: Duration) => void;
+    value: Duration | null;
+    onChange: (newValue: Duration | null) => void;
     min: Duration;
     max: Duration;
-    asString?: (value: Duration) => string;
+    asString?: (value: Duration | null) => string;
     fromString?: (raw: string) => Duration;
     normalize?: (dirty: string) => string;
     step?: Duration;
@@ -60,9 +60,16 @@ export interface ActivityDurationpickerSignature {
   Element: HTMLInputElement;
 }
 
+const _durationAsString = (duration: Duration | null) =>
+  duration ? durationAsString(duration) : "";
+
 export default class Durationpicker extends Component<BaseDurationpickerSignature> {
   get asString() {
-    return durationAsString;
+    return this.args.asString ?? _durationAsString;
+  }
+
+  get value() {
+    return this.args.value ?? Duration.fromMillis(0);
   }
 
   get clamp() {
@@ -86,8 +93,24 @@ export default class Durationpicker extends Component<BaseDurationpickerSignatur
     return this.args.bigStep ?? Duration.fromObject({ hours: 1 });
   }
 
+  onInput = (e: Event) => {
+    const target = e.target as HTMLInputElement;
+    // if the input is empty/cleared, we set the duration to null
+    // otherwise arrow keys / scroll wheel would use the previous time
+    if (!target.value) {
+      this.args.onChange(null);
+    }
+  };
+
   onChange = (e: Event) => {
     const target = e.target as HTMLInputElement;
+
+    // prevent normalize() running on empty strings
+    if (!target.value) {
+      // no need to `onChange(null)` here, since `onInput` already did that
+      return;
+    }
+
     const clean = this.normalize(target.value);
     target.value = clean;
 
@@ -98,25 +121,21 @@ export default class Durationpicker extends Component<BaseDurationpickerSignatur
   };
 
   onKeydown = (e: KeyboardEvent) => {
-    const { value, onChange } = this.args;
-
     if (e.shiftKey || !(e.key === "ArrowUp" || e.key === "ArrowDown")) {
       return;
     }
 
-    const result = value[e.key === "ArrowUp" ? "plus" : "minus"](
+    const result = this.value[e.key === "ArrowUp" ? "plus" : "minus"](
       e.ctrlKey ? this.bigStep : this.step,
     );
 
-    onChange(this.clamp(result).rescale());
+    this.args.onChange(this.clamp(result).rescale());
   };
 
   onMousewheel = (e: WheelEvent) => {
-    const { value, onChange } = this.args;
+    const result = this.value[e.deltaY < 0 ? "plus" : "minus"](this.step);
 
-    const result = value[e.deltaY < 0 ? "plus" : "minus"](this.step);
-
-    onChange(this.clamp(result).rescale());
+    this.args.onChange(this.clamp(result).rescale());
   };
 
   <template>
@@ -125,6 +144,7 @@ export default class Durationpicker extends Component<BaseDurationpickerSignatur
       {{on "change" this.onChange}}
       {{on "keydown" this.onKeydown}}
       {{on "wheel" this.onMousewheel}}
+      {{on "input" this.onInput}}
       value={{this.asString @value}}
       ...attributes
       type="text"

--- a/ember/ui-core/tests/integration/components/durationpicker-test.gts
+++ b/ember/ui-core/tests/integration/components/durationpicker-test.gts
@@ -22,7 +22,10 @@ module("Integration | Component | durationpicker", function (hooks) {
     const max = Duration.fromObject({ days: 10 });
 
     class State {
-      @tracked duration = Duration.fromObject({ hours: 2, minutes: 20 });
+      @tracked duration = Duration.fromObject({
+        hours: 2,
+        minutes: 20,
+      }) as Duration | null;
     }
 
     const state = new State();
@@ -46,7 +49,10 @@ module("Integration | Component | durationpicker", function (hooks) {
     const max = Duration.fromObject({ days: 10 });
 
     class State {
-      @tracked duration = Duration.fromObject({ hours: 2, minutes: 20 });
+      @tracked duration = Duration.fromObject({
+        hours: 2,
+        minutes: 20,
+      }) as Duration | null;
     }
 
     const state = new State();
@@ -71,7 +77,10 @@ module("Integration | Component | durationpicker", function (hooks) {
     const step = Duration.fromObject({ minutes: 10 });
 
     class State {
-      @tracked duration = Duration.fromObject({ hours: 0, minutes: 10 });
+      @tracked duration = Duration.fromObject({
+        hours: 0,
+        minutes: 10,
+      }) as Duration | null;
     }
 
     const state = new State();
@@ -104,7 +113,9 @@ module("Integration | Component | durationpicker", function (hooks) {
 
   test("report durationpicker", async function (assert) {
     class State {
-      @tracked duration = Duration.fromObject({ minutes: 15 });
+      @tracked duration = Duration.fromObject({
+        minutes: 15,
+      }) as Duration | null;
     }
 
     const state = new State();
@@ -131,7 +142,9 @@ module("Integration | Component | durationpicker", function (hooks) {
 
   test("activity durationpicker", async function (assert) {
     class State {
-      @tracked duration = Duration.fromObject({ minutes: 5 });
+      @tracked duration = Duration.fromObject({
+        minutes: 5,
+      }) as Duration | null;
     }
 
     const state = new State();
@@ -151,5 +164,44 @@ module("Integration | Component | durationpicker", function (hooks) {
 
     await fillIn("input", "120");
     assert.dom("input").hasValue("01:20");
+  });
+
+  test("it supports empty durations", async function (assert) {
+    class State {
+      @tracked duration = null as Duration | null;
+    }
+
+    const state = new State();
+
+    await render(
+      <template>
+        <ReportDurationpicker
+          @value={{state.duration}}
+          @onChange={{fn (mut state.duration)}}
+        />
+      </template>,
+    );
+    assert.dom("input").hasNoValue();
+
+    await triggerKeyEvent("input", "keydown", "ArrowDown");
+    assert.dom("input").hasValue("00:15"); // the minimum
+
+    await fillIn("input", "");
+    assert.dom("input").hasNoValue();
+    assert.deepEqual(state.duration, null);
+
+    await triggerKeyEvent("input", "keydown", "ArrowUp", { ctrlKey: true }); // ctrl key -> big step
+    assert.dom("input").hasValue("01:00");
+
+    await fillIn("input", "");
+    assert.dom("input").hasNoValue();
+    assert.deepEqual(state.duration, null);
+
+    await fillIn("input", "130");
+    assert.dom("input").hasValue("01:30");
+    assert.equal(
+      state.duration?.milliseconds,
+      Duration.fromObject({ hours: 1, minutes: 30 }).milliseconds,
+    );
   });
 });


### PR DESCRIPTION
Before this, the `Durationpicker` components from `ui-core` did not support empty values, instead they would show `--:--`

Which is a regression, see e.g. https://github.com/adfinis/timed/pull/1339/changes/4a80c96c4a6be629124ca9adfd3c718b18af6960 