### PR TITLE
refactor(ember): cleanup date formatting

### DIFF
--- a/ember/frontend/app/analysis/index/template.gjs
+++ b/ember/frontend/app/analysis/index/template.gjs
@@ -8,6 +8,7 @@ import perform from "ember-concurrency/helpers/perform";
 import inViewport from "ember-in-viewport/modifiers/in-viewport";
 import { and, eq, not, notEq, or } from "ember-truth-helpers";
 import LoadingIcon from "ui-core/components/loading-icon";
+import { dateToString } from "ui-core/utils/date";
 
 import CanEdit from "timed/components/can-edit";
 import Checkmark from "timed/components/checkmark";
@@ -27,7 +28,6 @@ import Tr from "timed/components/table/tr";
 import TaskSelection from "timed/components/task-selection";
 import UserSelection from "timed/components/user-selection";
 import formatDuration from "timed/helpers/format-duration";
-import luxonFormat from "timed/helpers/luxon-format";
 import media from "timed/helpers/media";
 
 const Colgroup = <template>
@@ -390,7 +390,7 @@ const AnalysisIndexTemplate = <template>
                           }}
                         >
                           <Td>{{report.user.username}}</Td>
-                          <Td>{{luxonFormat report.date "dd.MM.yyyy"}}</Td>
+                          <Td>{{dateToString report.date}}</Td>
                           <Td>{{formatDuration report.duration false}}</Td>
                           <Td>{{report.task.project.customer.name}}</Td>
                           <Td>{{report.task.project.name}}</Td>

--- a/ember/frontend/app/components/datepicker.gjs
+++ b/ember/frontend/app/components/datepicker.gjs
@@ -10,18 +10,12 @@ import preventDefault from "ember-event-helpers/helpers/prevent-default";
 import stopPropagation from "ember-event-helpers/helpers/stop-propagation";
 import { scheduleTask } from "ember-lifeline";
 import { DateTime } from "luxon";
+import * as date from "ui-core/utils/date";
 
 import Calendar from "timed/components/calendar";
 
-const DISPLAY_FORMAT = "dd.MM.yyyy";
-
-const PARSE_FORMAT = "d.M.yyyy";
-
-const parse = (value) =>
-  value ? DateTime.fromFormat(value, PARSE_FORMAT) : null;
-
 export default class Datepicker extends Component {
-  placeholder = DISPLAY_FORMAT;
+  placeholder = date.PRETTY_FORMAT;
 
   @tracked center;
 
@@ -34,7 +28,7 @@ export default class Datepicker extends Component {
 
   get displayValue() {
     return this.args.value && this.args.value.isValid
-      ? this.args.value.toFormat(DISPLAY_FORMAT)
+      ? date.toString(this.args.value)
       : null;
   }
 
@@ -65,7 +59,7 @@ export default class Datepicker extends Component {
   deferredWork() {
     const target = document.getElementById(this.uniqueId);
 
-    const parsed = parse(target.value);
+    const parsed = date.fromString(target.value);
 
     if (parsed && !parsed.isValid) {
       return target.setCustomValidity("Invalid date");
@@ -82,7 +76,7 @@ export default class Datepicker extends Component {
     },
   }) {
     if (valid) {
-      const parsed = parse(value);
+      const parsed = date.fromString(value);
 
       return this.args.onChange(parsed && parsed.isValid ? parsed : null);
     }

--- a/ember/frontend/app/components/worktime-balance-chart.gjs
+++ b/ember/frontend/app/components/worktime-balance-chart.gjs
@@ -1,6 +1,7 @@
 import Component from "@glimmer/component";
 import EmberChart from "ember-cli-chart/components/ember-chart";
 import { Duration } from "luxon";
+import { dateToString } from "ui-core/utils/date";
 
 import humanizeDuration from "timed/utils/humanize-duration";
 
@@ -106,7 +107,7 @@ export default class WorktimeBalanceChart extends Component {
         yPadding: 10,
         callbacks: {
           title([{ index }], { labels }) {
-            return labels[index].toFormat("dd.MM.yyyy");
+            return dateToString(labels[index]);
           },
           label({ yLabel: hours }) {
             return humanizeDuration(Duration.fromObject({ hours }));

--- a/ember/frontend/app/index/template.gjs
+++ b/ember/frontend/app/index/template.gjs
@@ -12,6 +12,7 @@ import PowerCalendar from "ember-power-calendar/components/power-calendar";
 import PowerCalendarMultiple from "ember-power-calendar/components/power-calendar-multiple";
 import { eq, or } from "ember-truth-helpers";
 import ValidatedForm from "ember-validated-form/components/validated-form";
+import { WEEKDAY_DISPLAY_FORMAT } from "ui-core/utils/date";
 
 import DateNavigation from "timed/components/date-navigation";
 import Modal from "timed/components/modal";
@@ -26,13 +27,14 @@ import WeeklyOverviewDay from "timed/components/weekly-overview-day";
 import humanizeDuration from "timed/helpers/humanize-duration";
 import luxonFormat from "timed/helpers/luxon-format";
 import media from "timed/helpers/media";
+
 <template>
   <TrackingBar data-test-tracking-bar />
   <div class="grid--12of12 grid">
     <div class="grid md:grid-cols-[minmax(0,1fr),auto]">
       <h1 class="block max-md:mb-2">{{luxonFormat
           @model
-          "EEEE, dd.MM.yyyy"
+          WEEKDAY_DISPLAY_FORMAT
         }}</h1>
       <DateNavigation
         @current={{@controller.date}}

--- a/ember/frontend/app/users/edit/credits/index/template.gjs
+++ b/ember/frontend/app/users/edit/credits/index/template.gjs
@@ -7,6 +7,7 @@ import perform from "ember-concurrency/helpers/perform";
 import { eq, not } from "ember-truth-helpers";
 import LoadingIcon from "ui-core/components/loading-icon";
 import Card from "ui-core/components/ui-card";
+import { dateToString } from "ui-core/utils/date";
 
 import Empty from "timed/components/empty";
 import Table from "timed/components/table";
@@ -15,7 +16,7 @@ import Th from "timed/components/table/th";
 import Thead from "timed/components/table/thead";
 import Tr from "timed/components/table/tr";
 import humanizeDuration from "timed/helpers/humanize-duration";
-import luxonFormat from "timed/helpers/luxon-format";
+
 <template>
   <div class="grid gap-2 sm:grid-cols-2">
     <div class="year-select col-span-full flex justify-end gap-2">
@@ -88,7 +89,7 @@ import luxonFormat from "timed/helpers/luxon-format";
                           )
                         }}
                       >
-                        <Td>{{luxonFormat absenceCredit.date "dd.MM.yyyy"}}</Td>
+                        <Td>{{dateToString absenceCredit.date}}</Td>
                         <Td>{{absenceCredit.days}}</Td>
                         <Td>{{absenceCredit.absenceType.name}}</Td>
                         <Td>{{absenceCredit.comment}}</Td>
@@ -161,10 +162,7 @@ import luxonFormat from "timed/helpers/luxon-format";
                           )
                         }}
                       >
-                        <Td>{{luxonFormat
-                            overtimeCredit.date
-                            "dd.MM.yyyy"
-                          }}</Td>
+                        <Td>{{dateToString overtimeCredit.date}}</Td>
                         <Td>{{humanizeDuration
                             overtimeCredit.duration
                             false

--- a/ember/frontend/app/users/edit/index/template.gjs
+++ b/ember/frontend/app/users/edit/index/template.gjs
@@ -6,6 +6,7 @@ import { DateTime } from "luxon";
 import { trackedTask } from "reactiveweb/ember-concurrency";
 import LoadingIcon from "ui-core/components/loading-icon";
 import Card from "ui-core/components/ui-card";
+import { dateToString } from "ui-core/utils/date";
 
 import Empty from "timed/components/empty";
 import Table from "timed/components/table";
@@ -14,7 +15,6 @@ import Th from "timed/components/table/th";
 import Thead from "timed/components/table/thead";
 import Tr from "timed/components/table/tr";
 import humanizeDuration from "timed/helpers/humanize-duration";
-import luxonFormat from "timed/helpers/luxon-format";
 
 export default class UsersEditIndexTemplate extends Component {
   @service store;
@@ -116,10 +116,10 @@ export default class UsersEditIndexTemplate extends Component {
                       <Tr @striped={{true}} @last={{true}}>
                         <Td>{{employment.location.name}}</Td>
                         <Td>{{employment.percentage}}%</Td>
-                        <Td>{{luxonFormat employment.start "dd.MM.yyyy"}}</Td>
+                        <Td>{{dateToString employment.start}}</Td>
                         <Td>{{if
                             employment.end
-                            (luxonFormat employment.end "dd.MM.yyyy")
+                            (dateToString employment.end)
                             "-"
                           }}</Td>
                       </Tr>
@@ -162,7 +162,7 @@ export default class UsersEditIndexTemplate extends Component {
                     {{#each absences as |absence|}}
                       <Tr @striped={{true}} @last={{true}}>
                         <Td>{{absence.absenceType.name}}</Td>
-                        <Td>{{luxonFormat absence.date "dd.MM.yyyy"}}</Td>
+                        <Td>{{dateToString absence.date}}</Td>
                         <Td>{{absence.comment}}</Td>
                       </Tr>
                     {{/each}}

--- a/ember/frontend/app/users/edit/template.gjs
+++ b/ember/frontend/app/users/edit/template.gjs
@@ -2,13 +2,13 @@ import { LinkTo } from "@ember/routing";
 import can from "ember-can/helpers/can";
 import { or } from "ember-truth-helpers";
 import LoadingIcon from "ui-core/components/loading-icon";
+import { dateToString } from "ui-core/utils/date";
 
 import BalanceDonut from "timed/components/balance-donut";
 import NoPermission from "timed/components/no-permission";
 import WorktimeBalanceChart from "timed/components/worktime-balance-chart";
 import balanceHighlightClass from "timed/helpers/balance-highlight-class";
 import formatDuration from "timed/helpers/format-duration";
-import luxonFormat from "timed/helpers/luxon-format";
 import media from "timed/helpers/media";
 
 <template>
@@ -46,9 +46,8 @@ import media from "timed/helpers/media";
                   title="Last day with timesheet entries or absences"
                   class="text-foreground-muted text-base uppercase sm:text-lg md:text-xl lg:text-2xl"
                 >
-                  {{luxonFormat
+                  {{dateToString
                     (or balance.date @model.activeEmployment.start)
-                    "dd.MM.yyyy"
                   }}
                 </h2>
                 <div

--- a/ember/frontend/tests/acceptance/statistics-test.js
+++ b/ember/frontend/tests/acceptance/statistics-test.js
@@ -2,6 +2,7 @@ import { click, fillIn, currentURL, visit, find } from "@ember/test-helpers";
 import { authenticateSession } from "ember-simple-auth/test-support";
 import { DateTime } from "luxon";
 import { module, test, skip } from "qunit";
+import { dateToString } from "ui-core/utils/date";
 
 import { setupApplicationTest } from "timed/tests/helpers";
 
@@ -75,11 +76,8 @@ module("Acceptance | statistics", function (hooks) {
     const from = DateTime.now();
     const to = DateTime.now().minus({ days: 10 });
 
-    await fillIn(
-      "[data-test-filter-from-date] input",
-      from.toFormat("dd.MM.yyyy"),
-    );
-    await fillIn("[data-test-filter-to-date] input", to.toFormat("dd.MM.yyyy"));
+    await fillIn("[data-test-filter-from-date] input", dateToString(from));
+    await fillIn("[data-test-filter-to-date] input", dateToString(to));
 
     assert.ok(currentURL().includes(`fromDate=${from.toISODate()}`));
     assert.ok(currentURL().includes(`toDate=${to.toISODate()}`));

--- a/ember/frontend/tests/acceptance/users-edit-credits-absence-credit-test.js
+++ b/ember/frontend/tests/acceptance/users-edit-credits-absence-credit-test.js
@@ -2,6 +2,7 @@ import { click, fillIn, currentURL, visit } from "@ember/test-helpers";
 import { authenticateSession } from "ember-simple-auth/test-support";
 import { DateTime } from "luxon";
 import { module, test } from "qunit";
+import { dateToString } from "ui-core/utils/date";
 
 import { setupApplicationTest } from "timed/tests/helpers";
 
@@ -19,7 +20,7 @@ module("Acceptance | users edit credits absence credit", function (hooks) {
     await visit(`/users/${this.user.id}/credits/absence-credits/new`);
 
     await click(".btn-group .btn:first-child");
-    await fillIn("input[name=date]", DateTime.now().toFormat("dd.MM.yyyy"));
+    await fillIn("input[name=date]", dateToString(DateTime.now()));
     await fillIn("input[name=days]", "5");
     await fillIn("input[name=comment]", "Comment");
     await click("[data-test-absence-credit-save]");
@@ -41,7 +42,7 @@ module("Acceptance | users edit credits absence credit", function (hooks) {
       `/users/${this.user.id}/credits/absence-credits/${id}`,
     );
 
-    await fillIn("input[name=date]", DateTime.now().toFormat("dd.MM.yyyy"));
+    await fillIn("input[name=date]", dateToString(DateTime.now()));
     await fillIn("input[name=days]", "5");
     await fillIn("input[name=comment]", "Ding dong");
 
@@ -55,7 +56,7 @@ module("Acceptance | users edit credits absence credit", function (hooks) {
       .dom(
         "[data-test-absence-credits] tbody > tr:first-child > td:nth-child(1)",
       )
-      .hasText(DateTime.now().toFormat("dd.MM.yyyy"));
+      .hasText(dateToString(DateTime.now()));
 
     assert
       .dom(
@@ -88,7 +89,7 @@ module("Acceptance | users edit credits absence credit", function (hooks) {
     await click(".btn-group .btn:first-child");
     await fillIn(
       "input[name=date]",
-      DateTime.now().plus({ years: 1 }).toFormat("dd.MM.yyyy"),
+      dateToString(DateTime.now().plus({ years: 1 })),
     );
     await fillIn("input[name=days]", "5");
     await fillIn("input[name=comment]", "Comment");

--- a/ember/frontend/tests/acceptance/users-edit-credits-overtime-credit-test.js
+++ b/ember/frontend/tests/acceptance/users-edit-credits-overtime-credit-test.js
@@ -2,6 +2,7 @@ import { click, fillIn, currentURL, visit } from "@ember/test-helpers";
 import { authenticateSession } from "ember-simple-auth/test-support";
 import { DateTime } from "luxon";
 import { module, test } from "qunit";
+import { dateToString } from "ui-core/utils/date";
 
 import { setupApplicationTest } from "timed/tests/helpers";
 
@@ -17,7 +18,7 @@ module("Acceptance | users edit credits overtime credit", function (hooks) {
   test("can create an overtime credit", async function (assert) {
     await visit(`/users/${this.user.id}/credits/overtime-credits/new`);
 
-    await fillIn("input[name=date]", DateTime.now().toFormat("dd.MM.yyyy"));
+    await fillIn("input[name=date]", dateToString(DateTime.now()));
     await fillIn("input[name=duration]", "20:00");
     await fillIn("input[name=comment]", "Comment");
 
@@ -40,7 +41,7 @@ module("Acceptance | users edit credits overtime credit", function (hooks) {
       `/users/${this.user.id}/credits/overtime-credits/${id}`,
     );
 
-    await fillIn("input[name=date]", DateTime.now().toFormat("dd.MM.yyyy"));
+    await fillIn("input[name=date]", dateToString(DateTime.now()));
     await fillIn("input[name=duration]", "20:00");
     await fillIn("input[name=comment]", "Ding dong");
 
@@ -54,7 +55,7 @@ module("Acceptance | users edit credits overtime credit", function (hooks) {
       .dom(
         "[data-test-overtime-credits] tbody > tr:first-child > td:nth-child(1)",
       )
-      .hasText(DateTime.now().toFormat("dd.MM.yyyy"));
+      .hasText(dateToString(DateTime.now()));
 
     assert
       .dom(
@@ -86,7 +87,7 @@ module("Acceptance | users edit credits overtime credit", function (hooks) {
 
     await fillIn(
       "input[name=date]",
-      DateTime.now().plus({ years: 1 }).toFormat("dd.MM.yyyy"),
+      dateToString(DateTime.now().plus({ years: 1 })),
     );
     await fillIn("input[name=duration]", "20:00");
     await fillIn("input[name=comment]", "Ding dong");

--- a/ember/frontend/tests/integration/components/datepicker/component-test.gjs
+++ b/ember/frontend/tests/integration/components/datepicker/component-test.gjs
@@ -4,6 +4,7 @@ import { clickTrigger } from "ember-basic-dropdown/test-support/helpers";
 import { setupRenderingTest } from "ember-qunit";
 import { DateTime } from "luxon";
 import { module, test } from "qunit";
+import { dateToString } from "ui-core/utils/date";
 
 import Datepicker from "timed/components/datepicker";
 
@@ -19,7 +20,7 @@ module("Integration | Component | datepicker", function (hooks) {
       </template>,
     );
 
-    assert.dom("input").hasValue(DateTime.now().toFormat("dd.MM.yyyy"));
+    assert.dom("input").hasValue(dateToString(DateTime.now()));
   });
 
   test("toggles the calendar on click of the input", async function (assert) {

--- a/ember/frontend/tests/integration/components/filter-sidebar/filter/component-test.gjs
+++ b/ember/frontend/tests/integration/components/filter-sidebar/filter/component-test.gjs
@@ -3,6 +3,7 @@ import { click, findAll, find, fillIn, render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
 import { DateTime } from "luxon";
 import { module, test } from "qunit";
+import { dateToString } from "ui-core/utils/date";
 
 import Filter from "timed/components/filter-sidebar/filter";
 
@@ -101,7 +102,7 @@ module("Integration | Component | filter sidebar/filter", function (hooks) {
       </template>,
     );
 
-    assert.dom("input").hasValue(this.selected.toFormat("dd.MM.yyyy"));
+    assert.dom("input").hasValue(dateToString(this.selected));
 
     await fillIn("input", "10.10.2010");
 

--- a/ember/frontend/tests/integration/components/worktime-balance-chart/component-test.gjs
+++ b/ember/frontend/tests/integration/components/worktime-balance-chart/component-test.gjs
@@ -2,6 +2,7 @@ import { render } from "@ember/test-helpers";
 import { setupRenderingTest } from "ember-qunit";
 import { DateTime, Duration } from "luxon";
 import { module, test } from "qunit";
+import { dateToString } from "ui-core/utils/date";
 
 import WorktimeBalanceChart from "timed/components/worktime-balance-chart";
 
@@ -54,7 +55,7 @@ module("Integration | Component | worktime balance chart", function (hooks) {
 
     assert.strictEqual(
       titleFn([{ index: 0 }], { labels: [DateTime.now()] }),
-      DateTime.now().toFormat("dd.MM.yyyy"),
+      dateToString(DateTime.now()),
     );
     assert.strictEqual(labelFn({ yLabel: 10.5 }), "10h 30m");
   });

--- a/ember/ui-core/src/utils/date.ts
+++ b/ember/ui-core/src/utils/date.ts
@@ -1,0 +1,30 @@
+import { DateTime } from "luxon";
+
+// human readable string for the date format (to use as e.g. placeholder)
+const PRETTY_FORMAT = "DD.MM.YYYY";
+
+// the format for luxon, to result in DD.MM.YYYY
+const LUXON_DISPLAY_FORMAT = "dd.MM.yyyy";
+
+// format for luxon, to result in `$WEEKDAY, DD.MM.YYYY`, e.g. `Wednesday, 24.06.2026`
+const WEEKDAY_DISPLAY_FORMAT = `EEEE, ${LUXON_DISPLAY_FORMAT}`;
+
+// we're a bit more lenient when parsing
+const LUXON_PARSE_FORMAT = "d.M.yyyy";
+
+// parse a DD.MM.YYYY string to a `DateTime` (for validity, check `dt.isValid`, this never returns null)
+const fromString = (value: string) =>
+  DateTime.fromFormat(value, LUXON_PARSE_FORMAT);
+
+// format a datetime into `DD.MM.YYYY` string
+const dateToString = (value: DateTime<true>) =>
+  value.toFormat(LUXON_DISPLAY_FORMAT);
+
+export {
+  fromString,
+  dateToString,
+  dateToString as toString,
+  PRETTY_FORMAT,
+  LUXON_DISPLAY_FORMAT,
+  WEEKDAY_DISPLAY_FORMAT,
+};

--- a/ember/ui-core/tests/unit/utils/date-test.ts
+++ b/ember/ui-core/tests/unit/utils/date-test.ts
@@ -1,0 +1,25 @@
+import * as date from "#src/utils/date.ts";
+import { DateTime } from "luxon";
+
+import { module, test } from "qunit";
+
+// small helper to reduce typing noise
+const fromISO = (s: string) => DateTime.fromISO(s) as DateTime<true>;
+
+module("Unit | Utility | date", function () {
+  test("toString works", function (assert) {
+    assert.deepEqual(date.toString(fromISO("2022-11-01")), "01.11.2022");
+
+    assert.deepEqual(date.toString(fromISO("2024-04-02")), "02.04.2024");
+  });
+
+  test("fromString works", function (assert) {
+    // valid dates in the "format"
+    assert.deepEqual(date.fromString("01.11.2022"), fromISO("2022-11-01"));
+    assert.deepEqual(date.fromString("02.04.2024"), fromISO("2024-04-02"));
+
+    // invalid dates -> invalid DateTimes
+    assert.false(date.fromString("not a valid date").isValid);
+    assert.false(date.fromString("2026-01-02").isValid);
+  });
+});


### PR DESCRIPTION
- utils for date formatting in `ui-core`
- de-duplicate `luxonFormat this.someDate "dd.MM.yyyy"` by using the date utils from `ui-core`
- fix placeholder in datepicker (it should be `DD.MM.YYYY` instead of `dd.MM.yyyy`)