### PR TITLE
fix(frontend) use ui-core's modal

### DIFF
--- a/ember/frontend/app/components/magic-link-modal.gjs
+++ b/ember/frontend/app/components/magic-link-modal.gjs
@@ -10,7 +10,7 @@ import toggle from "@nullvoxpopuli/ember-composable-helpers/helpers/toggle";
 import { not } from "ember-truth-helpers";
 
 import DurationpickerDay from "timed/components/durationpicker-day";
-import Modal from "timed/components/modal";
+import Modal from "timed/components/new-modal";
 import TaskSelection from "timed/components/task-selection";
 import Toggle from "timed/components/toggle";
 

--- a/ember/frontend/app/components/modal-target.gjs
+++ b/ember/frontend/app/components/modal-target.gjs
@@ -1,1 +1,8 @@
-<template><div id="modals" class="[&>*]:overflow-x-hidden" /></template>
+const TARGET_ID = "modals";
+
+const ModalTarget = <template>
+  <div id={{TARGET_ID}} class="[&>*]:overflow-x-hidden" />
+</template>;
+
+export default ModalTarget;
+export { TARGET_ID };

--- a/ember/frontend/app/components/new-modal.gjs
+++ b/ember/frontend/app/components/new-modal.gjs
@@ -37,6 +37,7 @@ export default class Modal extends Component {
       @target={{this.target}}
       @onClose={{optional @onClose}}
       @visible={{@visible}}
+      data-test-modal-visible={{@visible}}
       ...attributes
       as |m|
     >

--- a/ember/frontend/app/components/new-modal.gjs
+++ b/ember/frontend/app/components/new-modal.gjs
@@ -1,0 +1,46 @@
+import { deprecate } from "@ember/debug";
+import Component from "@glimmer/component";
+import UIModal from "ui-core/components/ui-modal";
+
+import { TARGET_ID } from "timed/components/modal-target";
+
+/** @param {((e: Event) => void)=} onClose */
+const optional = (onClose) => {
+  const hasNoOnClose = !onClose;
+  // TODO: remove this once we fix usages of the Modal component
+  deprecate(
+    "Not passing `@onClose` to a Modal component is deprecated. Refactor this component to pass a dedicated closing function.",
+    !hasNoOnClose,
+    {
+      id: "timed.modal.missing-on-close",
+      until: "6.0.0",
+      for: "timed",
+      since: {
+        available: "5.15.0",
+      },
+    },
+  );
+
+  if (hasNoOnClose) {
+    return () => {};
+  }
+
+  return onClose;
+};
+export default class Modal extends Component {
+  get target() {
+    return document.getElementById(TARGET_ID);
+  }
+
+  <template>
+    <UIModal
+      @target={{this.target}}
+      @onClose={{optional @onClose}}
+      @visible={{@visible}}
+      ...attributes
+      as |m|
+    >
+      {{yield m}}
+    </UIModal>
+  </template>
+}

--- a/ember/frontend/app/components/welcome-modal.gjs
+++ b/ember/frontend/app/components/welcome-modal.gjs
@@ -1,8 +1,9 @@
 import { on } from "@ember/modifier";
 import optional from "@nullvoxpopuli/ember-composable-helpers/helpers/optional";
 
-import Modal from "timed/components/modal";
+import Modal from "timed/components/new-modal";
 import TimedClock from "timed/components/timed-clock";
+
 <template>
   <Modal class="md:w-auto" @visible={{@visible}} as |modal|>
     <modal.header><h1 class="text-foreground">Welcome to Timed!</h1></modal.header>

--- a/ember/frontend/app/index/reports/template.gjs
+++ b/ember/frontend/app/index/reports/template.gjs
@@ -5,9 +5,10 @@ import toggle from "@nullvoxpopuli/ember-composable-helpers/helpers/toggle";
 import preventDefault from "ember-event-helpers/helpers/prevent-default";
 import PowerCalendar from "ember-power-calendar/components/power-calendar";
 
-import Modal from "timed/components/modal";
 import LowerButton from "timed/components/nav-tabs/lower-button";
+import Modal from "timed/components/new-modal";
 import ReportRow from "timed/components/report-row";
+
 <template>
   <LowerButton
     title="Move all entries to another date"

--- a/ember/frontend/tests/acceptance/tour-test.js
+++ b/ember/frontend/tests/acceptance/tour-test.js
@@ -28,7 +28,7 @@ module("Acceptance | tour", function (hooks) {
   test("shows a welcome dialog", async function (assert) {
     await visit("/");
 
-    assert.dom(".modal--visible").exists();
+    assert.dom("[data-test-modal-visible]").exists();
   });
 
   test("does not show a welcome dialog when tour completed", async function (assert) {
@@ -42,13 +42,13 @@ module("Acceptance | tour", function (hooks) {
 
     await visit("/");
 
-    assert.dom(".modal--visible").doesNotExist();
+    assert.dom("[data-test-modal-visible]").doesNotExist();
   });
 
   test("does not show a welcome dialog when later clicked", async function (assert) {
     await visit("/");
 
-    assert.dom(".modal--visible").exists();
+    assert.dom("[data-test-modal-visible]").exists();
 
     await click("[data-test-tour-later]");
 

--- a/ember/ui-core/demo-app/components/modal.ts
+++ b/ember/ui-core/demo-app/components/modal.ts
@@ -1,0 +1,3 @@
+const getModalsTarget = () => document.getElementById("modals")!;
+
+export { getModalsTarget };

--- a/ember/ui-core/demo-app/templates/index.gts
+++ b/ember/ui-core/demo-app/templates/index.gts
@@ -9,6 +9,7 @@ import { Duration } from "luxon";
 import Table from "#src/components/ui-table.gts";
 import { ReportDurationpicker } from "#src/components/ui-durationpicker.gts";
 import Checkbox from "#src/components/ui-checkbox.gts";
+import { getModalsTarget } from "../components/modal";
 
 type _Report = {
   customer: string;
@@ -142,6 +143,7 @@ export default class IndexTemplate extends Component {
         <Modal
           @visible={{this.visible}}
           @onClose={{fn (mut this.visible) false}}
+          @target={{(getModalsTarget)}}
           class="sm:min-w-[32rem] md:w-auto"
           as |m|
         >

--- a/ember/ui-core/src/components/ui-modal.gts
+++ b/ember/ui-core/src/components/ui-modal.gts
@@ -39,6 +39,7 @@ export interface ModalOverlaySignature {
 export interface ModalSignature {
   Args: {
     onClose: (e: Event) => void;
+    target: HTMLElement;
     visible: boolean;
   };
   Blocks: {
@@ -111,28 +112,22 @@ class ModalOverlay extends Component<ModalOverlaySignature> {
   </template>
 }
 
-class Modal extends Component<ModalSignature> {
-  get target() {
-    return document.getElementById("modals")!;
-  }
-
-  <template>
-    {{#if @visible}}
-      {{#in-element this.target insertBefore=null}}
-        <ModalOverlay @visible={{@visible}} @onClose={{@onClose}}>
-          <Card {{focusTrap}} class="z-50 max-h-[100%] w-full" ...attributes>
-            {{yield
-              (hash
-                footer=CardFooter
-                body=ModalBody
-                header=(component ModalHeader onClose=@onClose)
-              )
-            }}
-          </Card>
-        </ModalOverlay>
-      {{/in-element}}
-    {{/if}}
-  </template>
-}
+const Modal = <template>
+  {{#if @visible}}
+    {{#in-element @target insertBefore=null}}
+      <ModalOverlay @visible={{@visible}} @onClose={{@onClose}}>
+        <Card {{focusTrap}} class="z-50 max-h-[100%] w-full" ...attributes>
+          {{yield
+            (hash
+              footer=CardFooter
+              body=ModalBody
+              header=(component ModalHeader onClose=@onClose)
+            )
+          }}
+        </Card>
+      </ModalOverlay>
+    {{/in-element}}
+  {{/if}}
+</template> satisfies TOC<ModalSignature>;
 
 export default Modal;

--- a/ember/ui-core/tests/integration/components/modal-test.gts
+++ b/ember/ui-core/tests/integration/components/modal-test.gts
@@ -16,13 +16,17 @@ module("Integration | Component | modal", function (hooks) {
     }
     const state = new State();
 
+    const targetId = "modals";
+    const getTarget = () => document.getElementById(targetId)!;
+
     await render(
       <template>
-        <div id="modals" />
+        <div id={{targetId}} />
         <button type="button" {{on "click" (toggle "visible" state)}} />
         <Modal
           @visible={{state.visible}}
           @onClose={{toggle "visible" state}}
+          @target={{(getTarget)}}
           class="sm:min-w-[32rem] md:w-auto"
           as |m|
         >


### PR DESCRIPTION
We still have the old modal component in the activities tab, as changing resp. migrating it to the new Modal component is/would be a bigger story, that can be its own PR