### PR TITLE
fix(ember/styles): primary-dark colour ("old" theme)

### DIFF
--- a/ember/ui-core/src/styles/base.css
+++ b/ember/ui-core/src/styles/base.css
@@ -150,7 +150,7 @@
   --primary: rgb(var(--old-primary));
   --primary-dark: color-mix(
     in srgb,
-    var(--primary) 90%,
+    var(--primary) 50%,
     rgb(var(--dark-moderate-blue))
   );
 


### PR DESCRIPTION
fix `primary-dark` in the "old" theme

## before

<img width="1106" height="246" alt="image" src="https://github.com/user-attachments/assets/367a518d-faf4-46db-9844-6ee752256354" />

## after

<img width="1116" height="256" alt="image" src="https://github.com/user-attachments/assets/d2662999-0e95-47d3-a509-c283bf62ad8e" />
