### PR TITLE
fix(frontend): use ui-core's durationpickers 

### DIFF
--- a/ember/frontend/app/components/magic-link-modal.gjs
+++ b/ember/frontend/app/components/magic-link-modal.gjs
@@ -8,8 +8,8 @@ import { tracked } from "@glimmer/tracking";
 import pick from "@nullvoxpopuli/ember-composable-helpers/helpers/pick";
 import toggle from "@nullvoxpopuli/ember-composable-helpers/helpers/toggle";
 import { not } from "ember-truth-helpers";
+import { ReportDurationpicker } from "ui-core/components/ui-durationpicker";
 
-import DurationpickerDay from "timed/components/durationpicker-day";
 import Modal from "timed/components/modal";
 import TaskSelection from "timed/components/task-selection";
 import Toggle from "timed/components/toggle";
@@ -91,8 +91,7 @@ export default class MagicLinkModal extends Component {
           />
 
           <div class="flex">
-            <DurationpickerDay
-              @disabled={{false}}
+            <ReportDurationpicker
               @value={{this.duration}}
               @onChange={{fn (mut this.duration)}}
               @title="Task duration"

--- a/ember/frontend/app/users/edit/credits/overtime-credits/edit/template.gjs
+++ b/ember/frontend/app/users/edit/credits/overtime-credits/edit/template.gjs
@@ -5,12 +5,17 @@ import changeset from "ember-changeset/helpers/changeset";
 import perform from "ember-concurrency/helpers/perform";
 import { and, not, or } from "ember-truth-helpers";
 import ValidatedForm from "ember-validated-form/components/validated-form";
+import { Duration } from "luxon";
 import Card from "ui-core/components/ui-card";
+import Durationpicker from "ui-core/components/ui-durationpicker";
 
 import Datepicker from "timed/components/datepicker";
-import Durationpicker from "timed/components/durationpicker";
 import NoPermission from "timed/components/no-permission";
-<template>
+
+const MIN_CREDIT = Duration.fromObject({ minutes: 15 });
+const MAX_CREDIT = Duration.fromObject({ hours: 1000 });
+
+const UsersEditCreditsOvertimeCreditsEditTemplate = <template>
   {{#let @controller.credit.lastSuccessful.value as |credit|}}
     {{#if
       (or
@@ -40,6 +45,9 @@ import NoPermission from "timed/components/no-permission";
                 <div>
                   <f.input @label="Duration" @name="duration" as |fi|>
                     <Durationpicker
+                      name="duration"
+                      @min={{MIN_CREDIT}}
+                      @max={{MAX_CREDIT}}
                       @value={{fi.value}}
                       @onChange={{fi.update}}
                     />
@@ -88,4 +96,7 @@ import NoPermission from "timed/components/no-permission";
       </div>
     {{/if}}
   {{/let}}
-</template>
+</template>;
+
+export { MIN_CREDIT as OVERTIME_MIN_CREDIT, MAX_CREDIT as OVERTIME_MAX_CREDIT };
+export default UsersEditCreditsOvertimeCreditsEditTemplate;

--- a/ember/frontend/tests/acceptance/magic-link-test.js
+++ b/ember/frontend/tests/acceptance/magic-link-test.js
@@ -113,7 +113,10 @@ module("Acceptance | magic links", function (hooks) {
     await click("[data-test-magic-link-btn]");
 
     assert.dom("[data-test-magic-link-comment]").hasNoValue();
-    assert.dom("[data-test-magic-link-duration]").hasValue("00:00");
+    assert.dom("[data-test-magic-link-duration]").hasNoValue();
+    assert
+      .dom("[data-test-magic-link-duration]")
+      .hasAttribute("placeholder", "00:00");
   });
 
   test("draft reports can be created without a specific duration", async function (assert) {

--- a/ember/frontend/tests/acceptance/users-edit-credits-overtime-credit-test.js
+++ b/ember/frontend/tests/acceptance/users-edit-credits-overtime-credit-test.js
@@ -1,10 +1,15 @@
 import { click, fillIn, currentURL, visit } from "@ember/test-helpers";
 import { authenticateSession } from "ember-simple-auth/test-support";
-import { DateTime } from "luxon";
+import { DateTime, Duration } from "luxon";
 import { module, test } from "qunit";
 import { dateToString } from "ui-core/utils/date";
 
 import { setupApplicationTest } from "timed/tests/helpers";
+import {
+  OVERTIME_MAX_CREDIT,
+  OVERTIME_MIN_CREDIT,
+} from "timed/users/edit/credits/overtime-credits/edit/template";
+import humanizeDuration from "timed/utils/humanize-duration";
 
 module("Acceptance | users edit credits overtime credit", function (hooks) {
   setupApplicationTest(hooks);
@@ -98,5 +103,42 @@ module("Acceptance | users edit credits overtime credit", function (hooks) {
       currentURL(),
       `/users/${this.user.id}/credits?year=${DateTime.now().year + 1}`,
     );
+  });
+
+  test("can use shorthands for overtime credit & values get clamped", async function (assert) {
+    const { id } = this.server.create("overtime-credit", { user: this.user });
+
+    await visit(`/users/${this.user.id}/credits`);
+    const inputDuration = async (durationString) => {
+      await click("[data-test-overtime-credits] tbody > tr:first-child");
+
+      assert.strictEqual(
+        currentURL(),
+        `/users/${this.user.id}/credits/overtime-credits/${id}`,
+      );
+
+      await fillIn("input[name=date]", dateToString(DateTime.now()));
+      await fillIn("input[name=duration]", durationString);
+
+      await click("[data-test-overtime-credit-save]");
+
+      assert.strictEqual(currentURL(), `/users/${this.user.id}/credits`);
+    };
+
+    const assertDurationText = (text) =>
+      assert
+        .dom(
+          "[data-test-overtime-credits] tbody > tr:first-child > td:nth-child(2)",
+        )
+        .hasText(text);
+
+    await inputDuration("1300");
+    assertDurationText(humanizeDuration(Duration.fromObject({ hours: 13 })));
+
+    await inputDuration("123456789");
+    assertDurationText(humanizeDuration(OVERTIME_MAX_CREDIT));
+
+    await inputDuration("-10:20");
+    assertDurationText(humanizeDuration(OVERTIME_MIN_CREDIT));
   });
 });

--- a/ember/ui-core/src/components/ui-durationpicker.gts
+++ b/ember/ui-core/src/components/ui-durationpicker.gts
@@ -116,7 +116,7 @@ export default class Durationpicker extends Component<BaseDurationpickerSignatur
 
     const res = this.fromString(clean);
     if (res) {
-      this.args.onChange(this.clamp(res).rescale());
+      this.args.onChange(this.clamp(res));
     }
   };
 
@@ -129,13 +129,13 @@ export default class Durationpicker extends Component<BaseDurationpickerSignatur
       e.ctrlKey ? this.bigStep : this.step,
     );
 
-    this.args.onChange(this.clamp(result).rescale());
+    this.args.onChange(this.clamp(result));
   };
 
   onMousewheel = (e: WheelEvent) => {
     const result = this.value[e.deltaY < 0 ? "plus" : "minus"](this.step);
 
-    this.args.onChange(this.clamp(result).rescale());
+    this.args.onChange(this.clamp(result));
   };
 
   <template>

--- a/ember/ui-core/src/components/ui-durationpicker.gts
+++ b/ember/ui-core/src/components/ui-durationpicker.gts
@@ -116,7 +116,7 @@ export default class Durationpicker extends Component<BaseDurationpickerSignatur
 
     const res = this.fromString(clean);
     if (res) {
-      this.args.onChange(res);
+      this.args.onChange(this.clamp(res).rescale());
     }
   };
 

--- a/ember/ui-core/src/utils/activity-duration.ts
+++ b/ember/ui-core/src/utils/activity-duration.ts
@@ -41,7 +41,7 @@ const parseStringDuration = (duration: string) => {
       minutes: parseInt(day.minutes ?? "0"),
     });
   };
-  return clampReport(parse().rescale());
+  return clampReport(parse().shiftTo("hours", "minutes", "seconds"));
 };
 
 export { ACTIVITY_DURATION_MIN, ACTIVITY_DURATION_MAX, parseStringDuration };

--- a/ember/ui-core/src/utils/duration.ts
+++ b/ember/ui-core/src/utils/duration.ts
@@ -5,7 +5,7 @@ const roundDuration = (base: Duration) => (duration: Duration) => {
 
   return Duration.fromMillis(
     Math.round(duration.as("milliseconds") / baseMs) * baseMs,
-  ).rescale();
+  ).shiftTo("hours", "minutes", "seconds");
 };
 
 const clampDuration =
@@ -72,14 +72,11 @@ const parseDurationFromString = (duration: string) => {
 
   const { sign, hours, minutes } = match;
 
-  const result = Duration.fromObject(
-    {
-      hours: parseInt(hours ?? "0"),
-      minutes: parseInt(minutes ?? "0"),
-    },
-    { conversionAccuracy: "longterm" },
-  );
-  return (sign === "-" ? result.negate() : result).rescale();
+  const result = Duration.fromObject({
+    hours: parseInt(hours ?? "0"),
+    minutes: parseInt(minutes ?? "0"),
+  });
+  return (sign === "-" ? result.negate() : result).shiftTo("hours", "minutes");
 };
 
 export {

--- a/ember/ui-core/src/utils/report-duration.ts
+++ b/ember/ui-core/src/utils/report-duration.ts
@@ -63,7 +63,7 @@ const parseStringDuration = (duration: string) => {
       minutes: parseInt(report!.minutes ?? "0"),
     });
   };
-  return clampReport(parse().rescale());
+  return clampReport(parse().shiftTo("hours", "minutes"));
 };
 
 export { REPORT_DURATION_MIN, REPORT_DURATION_MAX, parseStringDuration };

--- a/ember/ui-core/tests/integration/components/durationpicker-test.gts
+++ b/ember/ui-core/tests/integration/components/durationpicker-test.gts
@@ -204,4 +204,32 @@ module("Integration | Component | durationpicker", function (hooks) {
       Duration.fromObject({ hours: 1, minutes: 30 }).milliseconds,
     );
   });
+
+  test("it clamps values", async function (assert) {
+    const min = Duration.fromObject({ minutes: 15 });
+    const max = Duration.fromObject({ hours: 1000 });
+
+    class State {
+      @tracked duration = Duration.fromObject({ hours: 1 }) as Duration | null;
+    }
+
+    const state = new State();
+
+    await render(
+      <template>
+        <Durationpicker
+          @min={{min}}
+          @max={{max}}
+          @value={{state.duration}}
+          @onChange={{fn (mut state.duration)}}
+        />
+      </template>,
+    );
+
+    await fillIn("input", "123456789");
+    assert.dom("input").hasValue("1000:00", "It does not exceed @max");
+
+    await fillIn("input", "-123456789");
+    assert.dom("input").hasValue("00:15", "It does not go below @min");
+  });
 });

--- a/ember/ui-core/tests/unit/utils/duration-test.ts
+++ b/ember/ui-core/tests/unit/utils/duration-test.ts
@@ -125,4 +125,12 @@ module("Unit | Utility | duration", function () {
       -(1200 * 60 + 45),
     );
   });
+
+  test("rounding keeps large durations as fixed durations", function (assert) {
+    const round = roundDuration(Duration.fromObject({ minutes: 15 }));
+    const rounded = round(Duration.fromObject({ hours: 999, minutes: 52 }));
+
+    assert.deepEqual(rounded.as("hours"), 999.75);
+    assert.deepEqual(durationAsString(rounded), "999:45");
+  });
 });

--- a/ember/ui-core/tests/unit/utils/duration-test.ts
+++ b/ember/ui-core/tests/unit/utils/duration-test.ts
@@ -86,7 +86,10 @@ module("Unit | Utility | duration", function () {
 
     assert.deepEqual(
       durationAsString(
-        Duration.fromObject({ minutes: -46, hours: -7 }).rescale(),
+        Duration.fromObject({ minutes: -46, hours: -7 }).shiftTo(
+          "hours",
+          "minutes",
+        ),
       ),
       "-07:46",
     );
@@ -98,7 +101,10 @@ module("Unit | Utility | duration", function () {
 
     assert.deepEqual(
       durationAsString(
-        Duration.fromObject({ hours: 123, minutes: 1 }).rescale(),
+        Duration.fromObject({ hours: 123, minutes: 1 }).shiftTo(
+          "hours",
+          "minutes",
+        ),
       ),
       "123:01",
     );


### PR DESCRIPTION
besides replacing more `timed/components/durationpicker*`s, this also fixed some bugs in the ui-core implementation of the durationpickers/duration utils (all split into seperate commits)