### PR TITLE
fix(frontend): change magic link icon to a wand with sparkles

### DIFF
--- a/ember/frontend/app/components/magic-link-btn.gjs
+++ b/ember/frontend/app/components/magic-link-btn.gjs
@@ -17,7 +17,7 @@ export default class MagicLinkBtn extends Component {
       {{on "click" (toggle "isModalVisible" this)}}
       ...attributes
     >
-      <FaIcon @icon="bolt" @prefix="fas" @size="sm" />
+      <FaIcon @icon="wand-magic-sparkles" @prefix="fas" @size="sm" />
       {{#if this.isModalVisible}}
         <MagicLinkModal
           @isVisible={{this.isModalVisible}}

--- a/ember/frontend/app/font-awesome.js
+++ b/ember/frontend/app/font-awesome.js
@@ -16,6 +16,7 @@ import {
   faUser,
 } from "@fortawesome/free-regular-svg-icons";
 import {
+  faWandMagicSparkles,
   faAngleRight,
   faAngleLeft,
   faArrowLeft,
@@ -100,4 +101,5 @@ library.add(
   faQuestion,
   faMagic,
   faCircleQuestion,
+  faWandMagicSparkles,
 );


### PR DESCRIPTION
While it is called "magic link", the icon is currently a bolt currently (as per #147)

Instead of that, we can make it a wand **with sparkles**, so it doesn't look like a pencil (see #78)

## before
<img width="391" height="97" alt="image" src="https://github.com/user-attachments/assets/fb15635f-d6a6-4ab6-9bb2-7fc8158054f5" />


## after
<img width="384" height="109" alt="image" src="https://github.com/user-attachments/assets/76d8aa7f-1c97-4e52-ab69-da0f2c208363" />
