### PR TITLE
fix(frontend): reorder inactive users

### DIFF
--- a/ember/frontend/app/components/user-selection.gjs
+++ b/ember/frontend/app/components/user-selection.gjs
@@ -8,6 +8,12 @@ import { trackedTask } from "reactiveweb/ember-concurrency";
 import OptimizedPowerSelectComponent from "timed/components/optimized-power-select";
 import customOptionTemplate from "timed/components/optimized-power-select/custom-options/user-option";
 import customSelectedTemplate from "timed/components/optimized-power-select/custom-select/user-selection";
+import sortArchivedLast from "timed/utils/sort-archived-last";
+
+const sortByInactiveAndName = sortArchivedLast(
+  (a, b) => (a.name > b.name ? 1 : -1),
+  (u) => !u.isActive,
+);
 
 export default class UserSelection extends Component {
   selectedTemplate = customSelectedTemplate;
@@ -40,7 +46,7 @@ export default class UserSelection extends Component {
   ]);
 
   get users() {
-    return this._users.value ?? [];
+    return (this._users.value ?? []).toSorted(sortByInactiveAndName);
   }
   <template>
     {{yield


### PR DESCRIPTION
move inactive users below active users (somewhat address #120) 

## before
<img width="348" height="488" alt="image" src="https://github.com/user-attachments/assets/473aa122-ec5e-428d-b212-ca2833cf28bf" />

## after
<img width="345" height="582" alt="image" src="https://github.com/user-attachments/assets/4032a7e5-89e3-47d8-bc8a-323314c39a0c" />
