### PR TITLE
fix(frontend): `queryOptions` in UserSelection being a nop

### DIFF
--- a/ember/frontend/app/components/user-selection.gjs
+++ b/ember/frontend/app/components/user-selection.gjs
@@ -22,11 +22,13 @@ export default class UserSelection extends Component {
   @service tracking;
   @service store;
 
-  @tracked queryOptions = null;
-
   constructor(...args) {
     super(...args);
     this.tracking.users.perform();
+  }
+
+  get queryOptions() {
+    return this.args.queryOptions;
   }
 
   usersTask = restartableTask(async () => {


### PR DESCRIPTION
there is one use of `UserSelection` with `@queryOptions={{hash is_reviwer=1}}` before this change, passing `@queryOptions` wouldn't do anything