### PR TITLE
fix(magic-link): button arrangement

### DIFF
--- a/ember/frontend/app/components/magic-link-btn.gjs
+++ b/ember/frontend/app/components/magic-link-btn.gjs
@@ -26,7 +26,7 @@ export default class MagicLinkBtn extends Component {
     <button
       type="button"
       data-test-magic-link-btn
-      title="Create a magic link"
+      title="Create a shareable link for the current task"
       class="btn btn-default"
       disabled={{if @requiresTask (not @task)}}
       {{on "click" this.toggleModal}}

--- a/ember/frontend/app/components/magic-link-modal.gjs
+++ b/ember/frontend/app/components/magic-link-modal.gjs
@@ -151,7 +151,7 @@ export default class MagicLinkModal extends Component {
             disabled={{true}}
             type="url"
             class="form-control mt-2 flex-grow rounded"
-            aria-label="magic link string"
+            aria-label="Create a shareable link"
             data-test-magic-link-string
           />
         </modal.body>

--- a/ember/frontend/app/index/activities/edit/template.gjs
+++ b/ember/frontend/app/index/activities/edit/template.gjs
@@ -104,13 +104,13 @@ import Timepicker from "timed/components/timepicker";
         </table>
       </c.footer>
       <c.footer class="flex justify-between text-right">
-        <LinkTo
-          @route="index.activities"
-          class="btn btn-default lg:hidden"
-          role="button"
-          data-test-activity-edit-form-cancel
-        >Cancel</LinkTo>
-        <div class="flex gap-2 lg:w-full lg:justify-between">
+        <div class="flex gap-2 lg:justify-end">
+          <LinkTo
+            @route="index.activities"
+            class="btn btn-default lg:hidden"
+            role="button"
+            data-test-activity-edit-form-cancel
+          >Cancel</LinkTo>
           <button
             class="btn btn-danger"
             type="button"
@@ -118,16 +118,24 @@ import Timepicker from "timed/components/timepicker";
             {{on "click" @controller.delete}}
             data-test-activity-edit-form-delete
           >Delete</button>
-          <MagicLinkBtn
-            @label="Magic Link"
-            @task={{@controller.changeset.task}}
-            @duration={{if @model.active null (roundToReport @model.duration)}}
-            @comment={{@controller.changeset.comment}}
-            @review={{@controller.changeset.review}}
-            @notBillable={{@controller.changeset.notBillable}}
-            @requiresTask={{true}}
-            data-test-activity-magic-link
-          />
+        </div>
+        <div class="flex gap-2 lg:justify-start">
+          {{#if @controller.changeset.task}}
+            <MagicLinkBtn
+              @label="Share"
+              @task={{@controller.changeset.task}}
+              @duration={{if
+                @model.active
+                null
+                (roundToReport @model.duration)
+              }}
+              @comment={{@controller.changeset.comment}}
+              @review={{@controller.changeset.review}}
+              @notBillable={{@controller.changeset.notBillable}}
+              @requiresTask={{true}}
+              data-test-activity-magic-link
+            />
+          {{/if}}
           <button
             class="btn btn-primary"
             type="submit"


### PR DESCRIPTION
Change the order of the activiy edit form.
* form action buttons (save/delete) are grouped left and therefore easier tab-targets (one tab for *save* as the primary action of the form)
* magic link button is separated a bit

## Before (desktop)
<img width="713" height="518" alt="image" src="https://github.com/user-attachments/assets/482862d3-8d44-4d3f-b1a0-46ac5d2a8d57" />

## After (desktop)
<img width="673" height="493" alt="image" src="https://github.com/user-attachments/assets/2cfe516c-51c5-41b8-9aab-810c1542aefd" />

---

## Before (mobile)

<img width="497" height="909" alt="image" src="https://github.com/user-attachments/assets/4efd39b1-4047-421c-9657-3aa7558b0e8b" />

## After (mobile)
<img width="534" height="827" alt="image" src="https://github.com/user-attachments/assets/b817d93c-1046-442e-9486-ebb3afe9b4fe" />
