### PR TITLE
fix(frontend/tracking-bar): record button styling

### DIFF
--- a/ember/frontend/app/components/tracking-bar.gjs
+++ b/ember/frontend/app/components/tracking-bar.gjs
@@ -56,7 +56,7 @@ export default class TrackingBar extends Component {
               @onSubmit={{perform this.tracking.startActivity}}
             />
           </div>
-          <div class="grid h-[2.5rem] place-self-start">
+          <div class="grid h-full place-self-center">
             <RecordButton
               @activity={{this.tracking.activity}}
               @recording={{this.tracking.activity.active}}


### PR DESCRIPTION
revert styling changes from 415f2cc34a1d53f7459f335af9908758c9a833c8

---

## before

<img width="1525" height="79" alt="image" src="https://github.com/user-attachments/assets/7160fb7d-00bd-4563-b04e-828d8fbf0f80" />

## after

<img width="1543" height="62" alt="image" src="https://github.com/user-attachments/assets/3e98c0a9-f4f5-4831-88c5-dbf879ad89c3" />
