### PR TITLE
fix(frontend/report-comment): refactor styling & positioning

### DIFF
--- a/ember/frontend/app/analysis/index/controller.js
+++ b/ember/frontend/app/analysis/index/controller.js
@@ -175,6 +175,7 @@ export default class AnalysisController extends QPController {
     this.resetQueryParams({ except: ["ordering"] });
   }
 
+  @action
   _reset() {
     this.data.cancelAll();
     this.loadNext.cancelAll();

--- a/ember/frontend/app/analysis/index/template.gjs
+++ b/ember/frontend/app/analysis/index/template.gjs
@@ -17,6 +17,7 @@ import Empty from "timed/components/empty";
 import FilterSidebar from "timed/components/filter-sidebar";
 import NoMobileMessage from "timed/components/no-mobile-message";
 import PagePermission from "timed/components/page-permission";
+import ReportComment from "timed/components/report-comment";
 import ScrollContainer from "timed/components/scroll-container";
 import SortHeader from "timed/components/sort-header";
 import Table from "timed/components/table";
@@ -80,17 +81,15 @@ const AnalysisIndexTemplate = <template>
               <fs.filter @label="Comment" data-test-filter-comment>
                 {{#let (uniqueId) as |id|}}
                   <label for={{id}} hidden>comment</label>
-                  <input
+                  <ReportComment
                     id={{id}}
-                    value={{@controller.comment}}
-                    {{on
-                      "change"
-                      (fn @controller.setModelFilterOnChange "comment")
-                    }}
-                    class="form-control comment-field rounded"
+                    @value={{@controller.comment}}
+                    @onChange={{fn (mut @controller.comment)}}
                     placeholder="Comment"
                     name="comment"
                     type="text"
+                    {{! we don't want to make a request on every keystroke (`@onChange` gets called on "input") }}
+                    {{on "change" @controller._reset}}
                   />
                 {{/let}}
               </fs.filter>

--- a/ember/frontend/app/components/report-comment.gjs
+++ b/ember/frontend/app/components/report-comment.gjs
@@ -160,7 +160,6 @@ export default class ReportCommentInput extends Component {
           {{if @customerVisible 'customer-comment'}}"
         placeholder="Comment"
         name="comment"
-        id="row-comment"
         value={{@value}}
         disabled={{@disabled}}
         title={{this.tooltip}}

--- a/ember/frontend/app/components/report-comment.gjs
+++ b/ember/frontend/app/components/report-comment.gjs
@@ -17,6 +17,10 @@ const elementModifier = modifier((element, [context]) => {
   context.inputElement = element;
 });
 
+const popoverModifier = modifier((element) => {
+  element.showPopover?.();
+  return () => element.hidePopover?.();
+});
 export default class ReportCommentInput extends Component {
   @service users;
 
@@ -152,11 +156,11 @@ export default class ReportCommentInput extends Component {
   }
 
   <template>
-    <div class="relative w-full">
+    <div class="relative w-full [anchor-scope:all]">
       <input
         ...attributes
         type="text"
-        class="comment-field w-full rounded
+        class="comment-field w-full rounded [anchor-name:--report-comment-anchor]
           {{if @customerVisible 'customer-comment'}}"
         placeholder="Comment"
         name="comment"
@@ -174,8 +178,10 @@ export default class ReportCommentInput extends Component {
       {{#if (and this.showDropdown this.filteredUsers.length)}}
         <ul
           data-test-report-comment-user-dropdown
-          class="bg-background text-foreground absolute left-0 top-full z-30 mt-1 max-h-48 min-w-64 overflow-y-auto border p-1 text-left"
+          class="bg-background text-foreground left-[anchor(left)] top-[anchor(bottom)] max-h-48 min-w-[anchor-size(width)] overflow-y-auto border p-1 text-left shadow-md [position-anchor:--report-comment-anchor]"
           role="listbox"
+          popover="manual"
+          {{popoverModifier}}
         >
           {{#each this.filteredUsers as |user index|}}
             <li

--- a/ember/frontend/app/components/report-row.gjs
+++ b/ember/frontend/app/components/report-row.gjs
@@ -1,4 +1,4 @@
-import { concat, fn } from "@ember/helper";
+import { concat, fn, uniqueId } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
 import { service } from "@ember/service";
@@ -98,14 +98,17 @@ export default class ReportRowComponent extends Component {
           </TaskSelection>
 
           <div class="form-list-cell form-group max-lg:col-span-full">
-            <label for="row-comment" hidden>Comment</label>
-            <ReportComment
-              @value={{cs.comment}}
-              @disabled={{not editable}}
-              @customerVisible={{cs.task.project.customerVisible}}
-              @onChange={{fn (mut cs.comment)}}
-              @onSubmit={{f.submitAction}}
-            />
+            {{#let (uniqueId) as |id|}}
+              <label for={{id}} hidden>Comment</label>
+              <ReportComment
+                id={{id}}
+                @value={{cs.comment}}
+                @disabled={{not editable}}
+                @customerVisible={{cs.task.project.customerVisible}}
+                @onChange={{fn (mut cs.comment)}}
+                @onSubmit={{f.submitAction}}
+              />
+            {{/let}}
           </div>
           <div class="form-list-cell form-group cell-duration">
             <ReportDurationpicker


### PR DESCRIPTION
- use `ReportComment` in the filter-sidebar (2fd49a125a9f85f25be116cc2872c89e090a3d1a)
- refactor styling/positioning (fb5b0584437f61aa92aaaadecc793763827f6d84)